### PR TITLE
feat(#36): 타임캡슐 좋아요, 상세보기 API 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,7 +83,6 @@ dependencies {
     // test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
-    testImplementation("org.mockito.kotlin:mockito-kotlin:5.4.0")
     testImplementation("io.mockk:mockk:1.13.10")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/src/main/kotlin/com/yapp/lettie/api/ApiPath.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/ApiPath.kt
@@ -19,6 +19,7 @@ enum class ApiPath(
     // 타임캡슐 관련 API
     TIME_CAPSULE_CREATE("/api/v1/capsule", HttpMethod.POST, AuthType.REQUIRED),
     TIME_CAPSULE_JOIN("/api/v1/capsule/{capsuleId}/join", HttpMethod.POST, AuthType.REQUIRED),
+    TIME_CAPSULE_LIKE("/api/v1/capsule/{capsuleId}/like", HttpMethod.POST, AuthType.REQUIRED),
 
     // Static 리소스 (로그인 불필요)
     STATIC_CSS("/css/*", HttpMethod.GET, AuthType.NONE),

--- a/src/main/kotlin/com/yapp/lettie/api/ApiPath.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/ApiPath.kt
@@ -69,11 +69,12 @@ enum class ApiPath(
             actualPath: String,
         ): Boolean {
             // {} 패턴과 * 패턴을 정규식으로 변환
-            val regexPattern = patternPath
-                .replace(Regex("\\{[^}]+}"), "[^/]+")
-                .replace(".", "\\.") // 리터럴 점 처리
-                .replace("/*", "(/.*)?") // 경로 끝 와일드카드 대응
-                .replace("*", "[^/]*")  // 경로 내부 와일드카드 대응
+            val regexPattern =
+                patternPath
+                    .replace(Regex("\\{[^}]+}"), "[^/]+")
+                    .replace(".", "\\.") // 리터럴 점 처리
+                    .replace("/*", "(/.*)?") // 경로 끝 와일드카드 대응
+                    .replace("*", "[^/]*") // 경로 내부 와일드카드 대응
 
             return actualPath.matches(Regex("^$regexPattern$"))
         }

--- a/src/main/kotlin/com/yapp/lettie/api/ApiPath.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/ApiPath.kt
@@ -20,6 +20,7 @@ enum class ApiPath(
     TIME_CAPSULE_CREATE("/api/v1/capsule", HttpMethod.POST, AuthType.REQUIRED),
     TIME_CAPSULE_JOIN("/api/v1/capsule/{capsuleId}/join", HttpMethod.POST, AuthType.REQUIRED),
     TIME_CAPSULE_LIKE("/api/v1/capsule/{capsuleId}/like", HttpMethod.POST, AuthType.REQUIRED),
+    TIME_CAPSULE_DETAIL("/api/v1/capsule/{capsuleId}", HttpMethod.GET, AuthType.OPTIONAL),
 
     // Static 리소스 (로그인 불필요)
     STATIC_CSS("/css/*", HttpMethod.GET, AuthType.NONE),
@@ -68,11 +69,11 @@ enum class ApiPath(
             actualPath: String,
         ): Boolean {
             // {} 패턴과 * 패턴을 정규식으로 변환
-            val regexPattern =
-                patternPath
-                    .replace(Regex("\\{[^}]+}"), "[^/]+") // {변수명}을 [^/]+ (슬래시가 아닌 문자들)로 변환
-                    .replace("*", ".*") // *을 .* (모든 문자)로 변환
-                    .replace(".", "\\.") // 리터럴 점(.)을 이스케이프 (예: favicon.ico)
+            val regexPattern = patternPath
+                .replace(Regex("\\{[^}]+}"), "[^/]+")
+                .replace(".", "\\.") // 리터럴 점 처리
+                .replace("/*", "(/.*)?") // 경로 끝 와일드카드 대응
+                .replace("*", "[^/]*")  // 경로 내부 와일드카드 대응
 
             return actualPath.matches(Regex("^$regexPattern$"))
         }

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/TimCapsuleDetailApiController.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/TimCapsuleDetailApiController.kt
@@ -2,6 +2,7 @@ package com.yapp.lettie.api.timecapsule.controller
 
 import com.yapp.lettie.api.auth.annotation.LoginUser
 import com.yapp.lettie.api.timecapsule.controller.response.TimeCapsuleDetailResponse
+import com.yapp.lettie.api.timecapsule.controller.swagger.TimeCapsuleDetailSwagger
 import com.yapp.lettie.api.timecapsule.service.TimeCapsuleDetailService
 import com.yapp.lettie.common.dto.ApiResponse
 import com.yapp.lettie.common.dto.UserInfoDto

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/TimCapsuleDetailApiController.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/TimCapsuleDetailApiController.kt
@@ -1,0 +1,34 @@
+package com.yapp.lettie.api.timecapsule.controller
+
+import com.yapp.lettie.api.auth.annotation.LoginUser
+import com.yapp.lettie.api.timecapsule.controller.response.TimeCapsuleDetailResponse
+import com.yapp.lettie.api.timecapsule.service.TimeCapsuleDetailService
+import com.yapp.lettie.common.dto.ApiResponse
+import com.yapp.lettie.common.dto.UserInfoDto
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/capsule")
+class TimCapsuleDetailApiController(
+    private val timeCapsuleDetailService: TimeCapsuleDetailService,
+) : TimeCapsuleDetailSwagger {
+    @GetMapping("/{capsuleId}")
+    override fun getCapsuleDetail(
+        @LoginUser UserInfo: UserInfoDto?,
+        @PathVariable capsuleId: Long,
+    ): ResponseEntity<ApiResponse<TimeCapsuleDetailResponse>> =
+        ResponseEntity.ok(
+            ApiResponse.success(
+                TimeCapsuleDetailResponse.from(
+                    timeCapsuleDetailService.getTimeCapsuleDetail(
+                        capsuleId = capsuleId,
+                        userId = UserInfo?.id,
+                    ),
+                ),
+            ),
+        )
+}

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/TimeCapsuleApiController.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/TimeCapsuleApiController.kt
@@ -4,8 +4,8 @@ import com.yapp.lettie.api.auth.annotation.LoginUser
 import com.yapp.lettie.api.timecapsule.controller.request.CreateTimeCapsuleRequest
 import com.yapp.lettie.api.timecapsule.controller.response.CreateTimeCapsuleResponse
 import com.yapp.lettie.api.timecapsule.controller.response.ToggleTimeCapsuleLikeResponse
-import com.yapp.lettie.api.timecapsule.service.TimeCapsuleService
 import com.yapp.lettie.api.timecapsule.controller.swagger.TimeCapsuleSwagger
+import com.yapp.lettie.api.timecapsule.service.TimeCapsuleService
 import com.yapp.lettie.common.dto.ApiResponse
 import com.yapp.lettie.common.dto.UserInfoDto
 import org.springframework.http.ResponseEntity

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/TimeCapsuleApiController.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/TimeCapsuleApiController.kt
@@ -5,7 +5,7 @@ import com.yapp.lettie.api.timecapsule.controller.request.CreateTimeCapsuleReque
 import com.yapp.lettie.api.timecapsule.controller.response.CreateTimeCapsuleResponse
 import com.yapp.lettie.api.timecapsule.controller.response.ToggleTimeCapsuleLikeResponse
 import com.yapp.lettie.api.timecapsule.service.TimeCapsuleService
-import com.yapp.lettie.api.timecapsule.swagger.TimeCapsuleSwagger
+import com.yapp.lettie.api.timecapsule.controller.swagger.TimeCapsuleSwagger
 import com.yapp.lettie.common.dto.ApiResponse
 import com.yapp.lettie.common.dto.UserInfoDto
 import org.springframework.http.ResponseEntity

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/TimeCapsuleApiController.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/TimeCapsuleApiController.kt
@@ -50,8 +50,8 @@ class TimeCapsuleApiController(
         ResponseEntity.ok(
             ApiResponse.success(
                 ToggleTimeCapsuleLikeResponse(
-                    timeCapsuleService.toggleLike(userInfo.id, capsuleId)
-                )
-            )
+                    timeCapsuleService.toggleLike(userInfo.id, capsuleId),
+                ),
+            ),
         )
 }

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/TimeCapsuleApiController.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/TimeCapsuleApiController.kt
@@ -3,6 +3,7 @@ package com.yapp.lettie.api.timecapsule.controller
 import com.yapp.lettie.api.auth.annotation.LoginUser
 import com.yapp.lettie.api.timecapsule.controller.request.CreateTimeCapsuleRequest
 import com.yapp.lettie.api.timecapsule.controller.response.CreateTimeCapsuleResponse
+import com.yapp.lettie.api.timecapsule.controller.response.ToggleTimeCapsuleLikeResponse
 import com.yapp.lettie.api.timecapsule.service.TimeCapsuleService
 import com.yapp.lettie.api.timecapsule.swagger.TimeCapsuleSwagger
 import com.yapp.lettie.common.dto.ApiResponse
@@ -23,15 +24,14 @@ class TimeCapsuleApiController(
     override fun create(
         @LoginUser userInfo: UserInfoDto,
         @RequestBody request: CreateTimeCapsuleRequest,
-    ): ResponseEntity<ApiResponse<CreateTimeCapsuleResponse>> {
-        return ResponseEntity.ok().body(
+    ): ResponseEntity<ApiResponse<CreateTimeCapsuleResponse>> =
+        ResponseEntity.ok().body(
             ApiResponse.success(
                 CreateTimeCapsuleResponse(
                     timeCapsuleService.createTimeCapsule(userInfo.id, request.to()),
                 ),
             ),
         )
-    }
 
     @PostMapping("/{capsuleId}/join")
     override fun join(
@@ -41,4 +41,17 @@ class TimeCapsuleApiController(
         timeCapsuleService.joinTimeCapsule(userInfo.id, capsuleId)
         return ResponseEntity.ok(ApiResponse.success(true))
     }
+
+    @PostMapping("/{capsuleId}/like")
+    override fun toggleLike(
+        @LoginUser userInfo: UserInfoDto,
+        @PathVariable capsuleId: Long,
+    ): ResponseEntity<ApiResponse<ToggleTimeCapsuleLikeResponse>> =
+        ResponseEntity.ok(
+            ApiResponse.success(
+                ToggleTimeCapsuleLikeResponse(
+                    timeCapsuleService.toggleLike(userInfo.id, capsuleId)
+                )
+            )
+        )
 }

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/TimeCapsuleDetailSwagger.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/TimeCapsuleDetailSwagger.kt
@@ -1,0 +1,32 @@
+package com.yapp.lettie.api.timecapsule.controller
+
+import com.yapp.lettie.api.timecapsule.controller.response.TimeCapsuleDetailResponse
+import com.yapp.lettie.common.dto.ApiResponse
+import com.yapp.lettie.common.dto.UserInfoDto
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.RequestMapping
+
+@Tag(name = "TimeCapsule Detail", description = "타임캡슐 Detail API (상세보기, 리스트 목록 반환)")
+@RequestMapping("/api/v1/capsule")
+interface TimeCapsuleDetailSwagger {
+    @Operation(
+        summary = "타임캡슐 상세 조회",
+        description =
+        """
+        캡슐의 기본 정보와 오픈일시, 참여자 수, 좋아요 여부, 상태 및 남은 시간을 조회합니다.
+        로그인하지 않은 사용자도 접근 가능하며, 로그인 사용자일 경우 좋아요 여부(liked)가 포함됩니다.
+
+        <status & remainingTime>
+        - 작성 마감 시점이 지나지 않은 경우: status = WRITABLE, remainingTime = closedAt - 현재
+        - 작성이 마감되고 캡슐 오픈까지 남은 경우: status = WAITING_OPEN, remainingTime = openedAt - 현재
+        - 타임캡슐이 오픈된 경우: status = OPENED, remainingTime = openedAt
+        """
+    )
+    fun getCapsuleDetail(
+        @Parameter(hidden = true) userInfo: UserInfoDto?,
+        capsuleId: Long,
+    ): ResponseEntity<ApiResponse<TimeCapsuleDetailResponse>>
+}

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/TimeCapsuleDetailSwagger.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/TimeCapsuleDetailSwagger.kt
@@ -15,7 +15,7 @@ interface TimeCapsuleDetailSwagger {
     @Operation(
         summary = "타임캡슐 상세 조회",
         description =
-        """
+            """
         캡슐의 기본 정보와 오픈일시, 참여자 수, 좋아요 여부, 상태 및 남은 시간을 조회합니다.
         로그인하지 않은 사용자도 접근 가능하며, 로그인 사용자일 경우 좋아요 여부(liked)가 포함됩니다.
 
@@ -23,7 +23,7 @@ interface TimeCapsuleDetailSwagger {
         - 작성 마감 시점이 지나지 않은 경우: status = WRITABLE, remainingTime = closedAt - 현재
         - 작성이 마감되고 캡슐 오픈까지 남은 경우: status = WAITING_OPEN, remainingTime = openedAt - 현재
         - 타임캡슐이 오픈된 경우: status = OPENED, remainingTime = openedAt
-        """
+        """,
     )
     fun getCapsuleDetail(
         @Parameter(hidden = true) userInfo: UserInfoDto?,

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/TimeCapsuleSwagger.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/TimeCapsuleSwagger.kt
@@ -34,11 +34,10 @@ interface TimeCapsuleSwagger {
 
     @Operation(
         summary = "타임캡슐 좋아요 토글",
-        description = "좋아요를 누르거나 취소합니다. 응답값이 true면 좋아요 상태, false면 좋아요 취소 상태입니다."
+        description = "좋아요를 누르거나 취소합니다. 응답값이 true면 좋아요 상태, false면 좋아요 취소 상태입니다.",
     )
     fun toggleLike(
         @Parameter(hidden = true) userInfo: UserInfoDto,
         capsuleId: Long,
     ): ResponseEntity<ApiResponse<ToggleTimeCapsuleLikeResponse>>
-
 }

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/TimeCapsuleSwagger.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/TimeCapsuleSwagger.kt
@@ -2,6 +2,7 @@ package com.yapp.lettie.api.timecapsule.swagger
 
 import com.yapp.lettie.api.timecapsule.controller.request.CreateTimeCapsuleRequest
 import com.yapp.lettie.api.timecapsule.controller.response.CreateTimeCapsuleResponse
+import com.yapp.lettie.api.timecapsule.controller.response.ToggleTimeCapsuleLikeResponse
 import com.yapp.lettie.common.dto.ApiResponse
 import com.yapp.lettie.common.dto.UserInfoDto
 import io.swagger.v3.oas.annotations.Operation
@@ -30,4 +31,14 @@ interface TimeCapsuleSwagger {
         @Parameter(hidden = true) userInfo: UserInfoDto,
         capsuleId: Long,
     ): ResponseEntity<ApiResponse<Boolean>>
+
+    @Operation(
+        summary = "타임캡슐 좋아요 토글",
+        description = "좋아요를 누르거나 취소합니다. 응답값이 true면 좋아요 상태, false면 좋아요 취소 상태입니다."
+    )
+    fun toggleLike(
+        @Parameter(hidden = true) userInfo: UserInfoDto,
+        capsuleId: Long,
+    ): ResponseEntity<ApiResponse<ToggleTimeCapsuleLikeResponse>>
+
 }

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/response/RemainingTimeResponse.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/response/RemainingTimeResponse.kt
@@ -1,0 +1,16 @@
+package com.yapp.lettie.api.timecapsule.controller.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+
+@Schema(description = "남은 시간 또는 오픈 날짜 정보")
+data class RemainingTimeResponse(
+    @Schema(description = "남은 일 수", example = "2", nullable = true)
+    val days: Long? = null,
+    @Schema(description = "남은 시간", example = "10", nullable = true)
+    val hours: Long? = null,
+    @Schema(description = "남은 분", example = "30", nullable = true)
+    val minutes: Long? = null,
+    @Schema(description = "오픈된 날짜 (상태가 OPENED일 경우만 존재)", example = "2025-07-01", nullable = true)
+    val openDate: LocalDate? = null,
+)

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/response/TimeCapsuleDetailResponse.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/response/TimeCapsuleDetailResponse.kt
@@ -1,0 +1,52 @@
+package com.yapp.lettie.api.timecapsule.controller.response
+
+import com.yapp.lettie.api.timecapsule.service.dto.TimeCapsuleDetailPayload
+import com.yapp.lettie.domain.timecapsule.entity.vo.TimeCapsuleStatus
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "타임캡슐 상세 응답")
+data class TimeCapsuleDetailResponse(
+    @Schema(description = "타임캡슐 ID", example = "123")
+    val id: Long,
+    @Schema(description = "제목", example = "비 오는 날의 타임캡슐")
+    val title: String,
+    @Schema(description = "내용", example = "비 오는 날에만 꺼내보고 싶은 이야기")
+    val subtitle: String?,
+    @Schema(description = "오픈 시각", example = "2025-07-01T13:00:00")
+    val openAt: LocalDateTime,
+    @Schema(description = "참여자 수", example = "8")
+    val participantCount: Int,
+    @Schema(description = "좋아요 수", example = "31")
+    val likeCount: Int,
+    @Schema(description = "좋아요 여부 (로그인 시에만 포함)", example = "true")
+    val isLiked: Boolean? = false,
+    @Schema(description = "캡슐 상태", example = "WRITABLE")
+    val status: TimeCapsuleStatus,
+    @Schema(description = "남은 시간 정보 또는 오픈 날짜")
+    val remainingTime: RemainingTimeResponse?,
+) {
+    companion object {
+        fun from(payload: TimeCapsuleDetailPayload): TimeCapsuleDetailResponse {
+            return TimeCapsuleDetailResponse(
+                id = payload.id,
+                title = payload.title,
+                subtitle = payload.subtitle,
+                openAt = payload.openAt,
+                participantCount = payload.participantCount,
+                likeCount = payload.likeCount,
+                isLiked = payload.isLiked,
+                status = payload.status,
+                remainingTime =
+                    payload.remainingTime?.let {
+                        RemainingTimeResponse(
+                            days = it.days,
+                            hours = it.hours,
+                            minutes = it.minutes,
+                            openDate = it.openDate,
+                        )
+                    },
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/response/ToggleTimeCapsuleLikeResponse.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/response/ToggleTimeCapsuleLikeResponse.kt
@@ -1,0 +1,8 @@
+package com.yapp.lettie.api.timecapsule.controller.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class ToggleTimeCapsuleLikeResponse (
+    @Schema(description = "timeCapsule Like", example = "true")
+    val isLiked: Boolean
+)

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/response/ToggleTimeCapsuleLikeResponse.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/response/ToggleTimeCapsuleLikeResponse.kt
@@ -2,7 +2,7 @@ package com.yapp.lettie.api.timecapsule.controller.response
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-data class ToggleTimeCapsuleLikeResponse (
+data class ToggleTimeCapsuleLikeResponse(
     @Schema(description = "timeCapsule Like", example = "true")
-    val isLiked: Boolean
+    val isLiked: Boolean,
 )

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/swagger/TimeCapsuleDetailSwagger.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/swagger/TimeCapsuleDetailSwagger.kt
@@ -1,4 +1,4 @@
-package com.yapp.lettie.api.timecapsule.controller
+package com.yapp.lettie.api.timecapsule.controller.swagger
 
 import com.yapp.lettie.api.timecapsule.controller.response.TimeCapsuleDetailResponse
 import com.yapp.lettie.common.dto.ApiResponse

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/swagger/TimeCapsuleSwagger.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/swagger/TimeCapsuleSwagger.kt
@@ -11,7 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RequestMapping
 
-@Tag(name = "TimeCapsule", description = "타임캡슐 관련 API")
+@Tag(name = "TimeCapsule Make", description = "타임캡슐 Make API (생성, 참여, 좋아요)")
 @RequestMapping("/api/v1/capsule")
 interface TimeCapsuleSwagger {
     @Operation(

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/swagger/TimeCapsuleSwagger.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/swagger/TimeCapsuleSwagger.kt
@@ -1,4 +1,4 @@
-package com.yapp.lettie.api.timecapsule.swagger
+package com.yapp.lettie.api.timecapsule.controller.swagger
 
 import com.yapp.lettie.api.timecapsule.controller.request.CreateTimeCapsuleRequest
 import com.yapp.lettie.api.timecapsule.controller.response.CreateTimeCapsuleResponse

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailService.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailService.kt
@@ -1,0 +1,89 @@
+package com.yapp.lettie.api.timecapsule.service
+
+import com.yapp.lettie.api.timecapsule.service.dto.RemainingTimePayload
+import com.yapp.lettie.api.timecapsule.service.dto.TimeCapsuleDetailPayload
+import com.yapp.lettie.api.timecapsule.service.reader.TimeCapsuleLikeReader
+import com.yapp.lettie.api.timecapsule.service.reader.TimeCapsuleReader
+import com.yapp.lettie.api.user.service.reader.UserReader
+import com.yapp.lettie.domain.timecapsule.entity.TimeCapsule
+import com.yapp.lettie.domain.timecapsule.entity.vo.TimeCapsuleStatus
+import org.springframework.stereotype.Service
+import java.time.Duration
+import java.time.LocalDateTime
+
+@Service
+class TimeCapsuleDetailService(
+    private val userReader: UserReader,
+    private val timeCapsuleReader: TimeCapsuleReader,
+    private val timeCapsuleLikeReader: TimeCapsuleLikeReader,
+) {
+    fun getTimeCapsuleDetail(
+        capsuleId: Long,
+        userId: Long? = null,
+    ): TimeCapsuleDetailPayload {
+        val capsule = timeCapsuleReader.getById(capsuleId)
+        val now = LocalDateTime.now()
+
+        val liked =
+            userId?.let {
+                val user = userReader.getById(it)
+                timeCapsuleLikeReader.findByUserAndCapsule(user, capsule)?.isLiked
+            }
+        val status = calculateStatus(now, capsule)
+        val remainingTime = calculateRemainingTime(now, capsule, status)
+
+        // TODO: 편지 몇 동있는지 추가
+        return TimeCapsuleDetailPayload(
+            id = capsule.id,
+            title = capsule.title,
+            subtitle = capsule.subtitle,
+            openAt = capsule.openAt,
+            participantCount = capsule.timeCapsuleUsers.size,
+            likeCount = capsule.timeCapsuleLikes.count { it.isLiked },
+            isLiked = liked,
+            status = status,
+            remainingTime = remainingTime,
+        )
+    }
+
+    private fun calculateStatus(
+        now: LocalDateTime,
+        capsule: TimeCapsule,
+    ): TimeCapsuleStatus {
+        return when {
+            now.isBefore(capsule.closedAt) -> TimeCapsuleStatus.WRITABLE
+            now.isBefore(capsule.openAt) -> TimeCapsuleStatus.WAITING_OPEN
+            else -> TimeCapsuleStatus.OPENED
+        }
+    }
+
+    private fun calculateRemainingTime(
+        now: LocalDateTime,
+        capsule: TimeCapsule,
+        status: TimeCapsuleStatus,
+    ): RemainingTimePayload {
+        return when (status) {
+            TimeCapsuleStatus.WRITABLE -> {
+                val duration = Duration.between(now, capsule.closedAt)
+                RemainingTimePayload(
+                    days = duration.toDays(),
+                    hours = duration.toHoursPart().toLong(),
+                    minutes = duration.toMinutesPart().toLong(),
+                )
+            }
+
+            TimeCapsuleStatus.WAITING_OPEN -> {
+                val duration = Duration.between(now, capsule.openAt)
+                RemainingTimePayload(
+                    days = duration.toDays(),
+                    hours = duration.toHoursPart().toLong(),
+                    minutes = duration.toMinutesPart().toLong(),
+                )
+            }
+
+            TimeCapsuleStatus.OPENED -> {
+                RemainingTimePayload(openDate = capsule.openAt.toLocalDate())
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleService.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleService.kt
@@ -61,7 +61,10 @@ class TimeCapsuleService(
     }
 
     @Transactional
-    fun toggleLike(userId: Long, capsuleId: Long): Boolean {
+    fun toggleLike(
+        userId: Long,
+        capsuleId: Long,
+    ): Boolean {
         val user = userReader.getById(userId)
         val capsule = timeCapsuleReader.getById(capsuleId)
         val existing = timeCapsuleLikeReader.findByUserAndCapsule(user, capsule)
@@ -76,7 +79,6 @@ class TimeCapsuleService(
             true
         }
     }
-
 
     private fun generateInviteCode(): String {
         return UUID.randomUUID().toString().take(RANDOM_VALUE_LENGTH)

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/dto/RemainingTimePayload.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/dto/RemainingTimePayload.kt
@@ -1,0 +1,10 @@
+package com.yapp.lettie.api.timecapsule.service.dto
+
+import java.time.LocalDate
+
+data class RemainingTimePayload(
+    val days: Long? = null,
+    val hours: Long? = null,
+    val minutes: Long? = null,
+    val openDate: LocalDate? = null,
+)

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/dto/TimeCapsuleDetailPayload.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/dto/TimeCapsuleDetailPayload.kt
@@ -1,0 +1,16 @@
+package com.yapp.lettie.api.timecapsule.service.dto
+
+import com.yapp.lettie.domain.timecapsule.entity.vo.TimeCapsuleStatus
+import java.time.LocalDateTime
+
+data class TimeCapsuleDetailPayload(
+    val id: Long,
+    val title: String,
+    val subtitle: String?,
+    val openAt: LocalDateTime,
+    val participantCount: Int,
+    val likeCount: Int,
+    val isLiked: Boolean? = null,
+    val status: TimeCapsuleStatus,
+    val remainingTime: RemainingTimePayload? = null,
+)

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/reader/TimeCapsuleLikeReader.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/reader/TimeCapsuleLikeReader.kt
@@ -14,13 +14,19 @@ class TimeCapsuleLikeReader(
     private val likeRepository: TimeCapsuleLikeRepository,
 ) {
     @Transactional(readOnly = true)
-    fun getByUserAndCapsule(user: User, capsule: TimeCapsule): TimeCapsuleLike {
+    fun getByUserAndCapsule(
+        user: User,
+        capsule: TimeCapsule,
+    ): TimeCapsuleLike {
         return findByUserAndCapsule(user, capsule)
             ?: throw ApiErrorException(ErrorMessages.CAPSULE_LIKE_NOT_FOUND)
     }
 
     @Transactional(readOnly = true)
-    fun findByUserAndCapsule(user: User, capsule: TimeCapsule): TimeCapsuleLike? {
+    fun findByUserAndCapsule(
+        user: User,
+        capsule: TimeCapsule,
+    ): TimeCapsuleLike? {
         return likeRepository.findByUserAndTimeCapsule(user, capsule)
     }
 }

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/reader/TimeCapsuleLikeReader.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/reader/TimeCapsuleLikeReader.kt
@@ -1,0 +1,26 @@
+package com.yapp.lettie.api.timecapsule.service.reader
+
+import com.yapp.lettie.common.error.ErrorMessages
+import com.yapp.lettie.common.exception.ApiErrorException
+import com.yapp.lettie.domain.timecapsule.entity.TimeCapsule
+import com.yapp.lettie.domain.timecapsule.entity.TimeCapsuleLike
+import com.yapp.lettie.domain.timecapsule.repository.TimeCapsuleLikeRepository
+import com.yapp.lettie.domain.user.entity.User
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class TimeCapsuleLikeReader(
+    private val likeRepository: TimeCapsuleLikeRepository,
+) {
+    @Transactional(readOnly = true)
+    fun getByUserAndCapsule(user: User, capsule: TimeCapsule): TimeCapsuleLike {
+        return findByUserAndCapsule(user, capsule)
+            ?: throw ApiErrorException(ErrorMessages.CAPSULE_LIKE_NOT_FOUND)
+    }
+
+    @Transactional(readOnly = true)
+    fun findByUserAndCapsule(user: User, capsule: TimeCapsule): TimeCapsuleLike? {
+        return likeRepository.findByUserAndTimeCapsule(user, capsule)
+    }
+}

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/writer/TimeCapsuleLikeWriter.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/writer/TimeCapsuleLikeWriter.kt
@@ -1,0 +1,16 @@
+package com.yapp.lettie.api.timecapsule.service.writer
+
+import com.yapp.lettie.domain.timecapsule.entity.TimeCapsuleLike
+import com.yapp.lettie.domain.timecapsule.repository.TimeCapsuleLikeRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class TimeCapsuleLikeWriter(
+    private val timeCapsuleLikeRepository: TimeCapsuleLikeRepository,
+) {
+    @Transactional
+    fun save(like: TimeCapsuleLike): TimeCapsuleLike {
+        return timeCapsuleLikeRepository.save(like)
+    }
+}

--- a/src/main/kotlin/com/yapp/lettie/common/error/ErrorMessages.kt
+++ b/src/main/kotlin/com/yapp/lettie/common/error/ErrorMessages.kt
@@ -24,5 +24,5 @@ enum class ErrorMessages(
     CAPSULE_NOT_FOUND(ExtendedHttpStatus.NOT_FOUND, 4_001, "타임캡슐을 찾을 수 없습니다."),
     ALREADY_JOINED(ExtendedHttpStatus.BAD_REQUEST, 4_002, "이미 참여한 타임캡슐입니다."),
     CLOSED_TIME_CAPSULE(ExtendedHttpStatus.BAD_REQUEST, 4_003, "닫힌 타임캡슐에는 참여할 수 없습니다."),
-    CAPSULE_LIKE_NOT_FOUND(ExtendedHttpStatus.NOT_FOUND, 4_004, "좋아요된 캡슐을 찾을 수 없습니다.")
+    CAPSULE_LIKE_NOT_FOUND(ExtendedHttpStatus.NOT_FOUND, 4_004, "좋아요된 캡슐을 찾을 수 없습니다."),
 }

--- a/src/main/kotlin/com/yapp/lettie/common/error/ErrorMessages.kt
+++ b/src/main/kotlin/com/yapp/lettie/common/error/ErrorMessages.kt
@@ -12,6 +12,8 @@ enum class ErrorMessages(
     ACCESS_DENIED(ExtendedHttpStatus.FORBIDDEN, 1_002, "해당 요청에 대한 권한이 없습니다."),
     INTERNAL_SERVER_ERROR(ExtendedHttpStatus.INTERNAL_SERVER_ERROR, 1_003, "서버 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."),
     INVALID_INPUT_VALUE(ExtendedHttpStatus.BAD_REQUEST, 1_004, "입력값이 올바르지 않습니다."),
+    NOT_FOUND(ExtendedHttpStatus.NOT_FOUND, 1_005, "요청하신 리소스를 찾을 수 없습니다."),
+    METHOD_NOT_ALLOWED(ExtendedHttpStatus.METHOD_NOT_ALLOWED, 1_006, "허용되지 않은 HTTP 메서드입니다."),
 
     // auth
     INVALID_TOKEN(ExtendedHttpStatus.UNAUTHORIZED, 2_001, "유효하지 않은 토큰입니다."),

--- a/src/main/kotlin/com/yapp/lettie/common/error/ErrorMessages.kt
+++ b/src/main/kotlin/com/yapp/lettie/common/error/ErrorMessages.kt
@@ -24,4 +24,5 @@ enum class ErrorMessages(
     CAPSULE_NOT_FOUND(ExtendedHttpStatus.NOT_FOUND, 4_001, "타임캡슐을 찾을 수 없습니다."),
     ALREADY_JOINED(ExtendedHttpStatus.BAD_REQUEST, 4_002, "이미 참여한 타임캡슐입니다."),
     CLOSED_TIME_CAPSULE(ExtendedHttpStatus.BAD_REQUEST, 4_003, "닫힌 타임캡슐에는 참여할 수 없습니다."),
+    CAPSULE_LIKE_NOT_FOUND(ExtendedHttpStatus.NOT_FOUND, 4_004, "좋아요된 캡슐을 찾을 수 없습니다.")
 }

--- a/src/main/kotlin/com/yapp/lettie/common/exception/ApiExceptionHandler.kt
+++ b/src/main/kotlin/com/yapp/lettie/common/exception/ApiExceptionHandler.kt
@@ -10,10 +10,10 @@ import mu.KotlinLogging
 import org.slf4j.MDC
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.HttpRequestMethodNotSupportedException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.servlet.NoHandlerFoundException
-import org.springframework.web.HttpRequestMethodNotSupportedException
 
 @RestControllerAdvice
 class ApiExceptionHandler(
@@ -63,7 +63,8 @@ class ApiExceptionHandler(
                 path = request.requestURI,
                 httpMethod = request.method,
                 exception = ex,
-                userId = null, // TODO: userId 넣기
+                // TODO: userId 넣기
+                userId = null,
                 notify = true,
                 logId = MDC.get(RequestIdFilter.REQUEST_ID),
             ),

--- a/src/main/kotlin/com/yapp/lettie/common/exception/ApiExceptionHandler.kt
+++ b/src/main/kotlin/com/yapp/lettie/common/exception/ApiExceptionHandler.kt
@@ -8,9 +8,12 @@ import com.yapp.lettie.common.logging.RequestIdFilter
 import jakarta.servlet.http.HttpServletRequest
 import mu.KotlinLogging
 import org.slf4j.MDC
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.servlet.NoHandlerFoundException
+import org.springframework.web.HttpRequestMethodNotSupportedException
 
 @RestControllerAdvice
 class ApiExceptionHandler(
@@ -26,6 +29,28 @@ class ApiExceptionHandler(
             .body(ApiResponse.error(ex.error))
     }
 
+    @ExceptionHandler(NoHandlerFoundException::class)
+    fun handleNotFoundException(
+        ex: NoHandlerFoundException,
+        request: HttpServletRequest,
+    ): ResponseEntity<ApiResponse<Nothing>> {
+        log.warn { "NoHandlerFoundException: ${request.method} ${request.requestURI}" }
+        return ResponseEntity
+            .status(HttpStatus.NOT_FOUND)
+            .body(ApiResponse.error(ApiError.of(ErrorMessages.NOT_FOUND)))
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException::class)
+    fun handleMethodNotAllowedException(
+        ex: HttpRequestMethodNotSupportedException,
+        request: HttpServletRequest,
+    ): ResponseEntity<ApiResponse<Nothing>> {
+        log.warn { "MethodNotAllowed: ${request.method} ${request.requestURI}" }
+        return ResponseEntity
+            .status(HttpStatus.METHOD_NOT_ALLOWED)
+            .body(ApiResponse.error(ApiError.of(ErrorMessages.METHOD_NOT_ALLOWED)))
+    }
+
     @ExceptionHandler(Exception::class)
     fun handleUnknownException(
         ex: Exception,
@@ -33,14 +58,12 @@ class ApiExceptionHandler(
     ): ResponseEntity<ApiResponse<Nothing>> {
         val error = ApiError.of(ErrorMessages.INTERNAL_SERVER_ERROR)
 
-        // 예외 분석 및 Discord 알림 비동기 위임
         llmErrorReporter.report(
             AnalyzeErrorRequest(
                 path = request.requestURI,
                 httpMethod = request.method,
                 exception = ex,
-                // TODO: 로그인 사용자 주입
-                userId = null,
+                userId = null, // TODO: userId 넣기
                 notify = true,
                 logId = MDC.get(RequestIdFilter.REQUEST_ID),
             ),
@@ -48,7 +71,8 @@ class ApiExceptionHandler(
 
         log.error(ex) { "처리되지 않은 서버 예외 발생" }
 
-        return ResponseEntity.status(error.status.code)
+        return ResponseEntity
+            .status(error.status.code)
             .body(ApiResponse.error(error))
     }
 }

--- a/src/main/kotlin/com/yapp/lettie/common/exception/ExtendedHttpStatus.kt
+++ b/src/main/kotlin/com/yapp/lettie/common/exception/ExtendedHttpStatus.kt
@@ -5,6 +5,7 @@ enum class ExtendedHttpStatus(val code: Int) {
     UNAUTHORIZED(401),
     FORBIDDEN(403),
     NOT_FOUND(404),
+    METHOD_NOT_ALLOWED(405),
     CONFLICT(409),
     INTERNAL_SERVER_ERROR(500),
     SERVICE_UNAVAILABLE(503),

--- a/src/main/kotlin/com/yapp/lettie/domain/timecapsule/entity/TimeCapsuleLike.kt
+++ b/src/main/kotlin/com/yapp/lettie/domain/timecapsule/entity/TimeCapsuleLike.kt
@@ -1,6 +1,5 @@
 package com.yapp.lettie.domain.timecapsule.entity
 
-import com.yapp.lettie.api.timecapsule.service.dto.CreateTimeCapsulePayload
 import com.yapp.lettie.domain.BaseEntity
 import com.yapp.lettie.domain.user.entity.User
 import jakarta.persistence.Column
@@ -29,8 +28,8 @@ class TimeCapsuleLike(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "capsule_id", nullable = false, foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val timeCapsule: TimeCapsule,
-) : BaseEntity(){
-    companion object{
+) : BaseEntity() {
+    companion object {
         fun of(
             user: User,
             timeCapsule: TimeCapsule,

--- a/src/main/kotlin/com/yapp/lettie/domain/timecapsule/entity/TimeCapsuleLike.kt
+++ b/src/main/kotlin/com/yapp/lettie/domain/timecapsule/entity/TimeCapsuleLike.kt
@@ -1,7 +1,9 @@
 package com.yapp.lettie.domain.timecapsule.entity
 
+import com.yapp.lettie.api.timecapsule.service.dto.CreateTimeCapsulePayload
 import com.yapp.lettie.domain.BaseEntity
 import com.yapp.lettie.domain.user.entity.User
+import jakarta.persistence.Column
 import jakarta.persistence.ConstraintMode
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
@@ -19,10 +21,24 @@ class TimeCapsuleLike(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0,
+    @Column(name = "is_liked", nullable = false)
+    var isLiked: Boolean = true,
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false, foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val user: User,
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "capsule_id", nullable = false, foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     val timeCapsule: TimeCapsule,
-) : BaseEntity()
+) : BaseEntity(){
+    companion object{
+        fun of(
+            user: User,
+            timeCapsule: TimeCapsule,
+        ): TimeCapsuleLike {
+            return TimeCapsuleLike(
+                user = user,
+                timeCapsule = timeCapsule,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/yapp/lettie/domain/timecapsule/entity/vo/TimeCapsuleStatus.kt
+++ b/src/main/kotlin/com/yapp/lettie/domain/timecapsule/entity/vo/TimeCapsuleStatus.kt
@@ -1,0 +1,7 @@
+package com.yapp.lettie.domain.timecapsule.entity.vo
+
+enum class TimeCapsuleStatus {
+    WRITABLE, // 편지 작성 가능 (현재 < closedAt)
+    WAITING_OPEN, // 작성 마감 이후 오픈 대기 (closedAt <= now < openAt)
+    OPENED,
+}

--- a/src/main/kotlin/com/yapp/lettie/domain/timecapsule/repository/TimeCapsuleLikeRepository.kt
+++ b/src/main/kotlin/com/yapp/lettie/domain/timecapsule/repository/TimeCapsuleLikeRepository.kt
@@ -6,6 +6,10 @@ import com.yapp.lettie.domain.user.entity.User
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface TimeCapsuleLikeRepository : JpaRepository<TimeCapsuleLike, Long> {
-    fun findByUserAndTimeCapsule(user: User, capsule: TimeCapsule): TimeCapsuleLike?
+    fun findByUserAndTimeCapsule(
+        user: User,
+        capsule: TimeCapsule,
+    ): TimeCapsuleLike?
+
     fun findByUserAndIsLikedTrue(user: User): List<TimeCapsuleLike>
 }

--- a/src/main/kotlin/com/yapp/lettie/domain/timecapsule/repository/TimeCapsuleLikeRepository.kt
+++ b/src/main/kotlin/com/yapp/lettie/domain/timecapsule/repository/TimeCapsuleLikeRepository.kt
@@ -1,10 +1,11 @@
 package com.yapp.lettie.domain.timecapsule.repository
 
+import com.yapp.lettie.domain.timecapsule.entity.TimeCapsule
 import com.yapp.lettie.domain.timecapsule.entity.TimeCapsuleLike
+import com.yapp.lettie.domain.user.entity.User
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface TimeCapsuleLikeRepository : JpaRepository<TimeCapsuleLike, Long> {
-    fun findByUserId(userId: Long): List<TimeCapsuleLike>
-
-    fun findByTimeCapsuleId(capsuleId: Long): List<TimeCapsuleLike>
+    fun findByUserAndTimeCapsule(user: User, capsule: TimeCapsule): TimeCapsuleLike?
+    fun findByUserAndIsLikedTrue(user: User): List<TimeCapsuleLike>
 }

--- a/src/main/resources/db/migration/V20250717_1__add_time_capsule_like_is_liked.sql
+++ b/src/main/resources/db/migration/V20250717_1__add_time_capsule_like_is_liked.sql
@@ -1,0 +1,2 @@
+ALTER TABLE time_capsule_like
+    ADD COLUMN is_liked BOOLEAN NOT NULL DEFAULT TRUE AFTER capsule_id;

--- a/src/test/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailServiceTest.kt
+++ b/src/test/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailServiceTest.kt
@@ -1,0 +1,133 @@
+package com.yapp.lettie.api.timecapsule.service
+
+import com.yapp.lettie.api.timecapsule.service.reader.TimeCapsuleLikeReader
+import com.yapp.lettie.api.timecapsule.service.reader.TimeCapsuleReader
+import com.yapp.lettie.api.user.service.reader.UserReader
+import com.yapp.lettie.domain.timecapsule.entity.TimeCapsule
+import com.yapp.lettie.domain.timecapsule.entity.TimeCapsuleLike
+import com.yapp.lettie.domain.timecapsule.entity.TimeCapsuleUser
+import com.yapp.lettie.domain.timecapsule.entity.vo.TimeCapsuleStatus
+import com.yapp.lettie.domain.user.entity.User
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.time.LocalDateTime
+
+@ExtendWith(MockKExtension::class)
+class TimeCapsuleDetailServiceTest {
+    @MockK lateinit var userReader: UserReader
+
+    @MockK lateinit var capsuleReader: TimeCapsuleReader
+
+    @MockK lateinit var likeReader: TimeCapsuleLikeReader
+
+    @InjectMockKs
+    lateinit var detailService: TimeCapsuleDetailService
+
+    @Test
+    fun `캡슐이 WRITABLE 상태일 때, 상세 정보를 정확히 반환한다`() {
+        // given
+        val now = LocalDateTime.now()
+        val userId = 1L
+        val capsuleId = 10L
+        val user = mockk<User>()
+        val capsule = mockk<TimeCapsule>()
+        val like = mockk<TimeCapsuleLike>()
+        val userList = listOf(mockk<TimeCapsuleUser>(), mockk())
+        val likeList = listOf(mockk<TimeCapsuleLike>().apply { every { isLiked } returns true })
+
+        every { capsuleReader.getById(capsuleId) } returns capsule
+        every { userReader.getById(userId) } returns user
+        every { likeReader.findByUserAndCapsule(user, capsule) } returns like
+        every { like.isLiked } returns true
+
+        every { capsule.id } returns capsuleId
+        every { capsule.title } returns "캡슐 제목"
+        every { capsule.subtitle } returns "부제목"
+        every { capsule.openAt } returns now.plusDays(3)
+        every { capsule.closedAt } returns now.plusDays(2)
+        every { capsule.timeCapsuleUsers } returns userList.toMutableList()
+        every { capsule.timeCapsuleLikes } returns likeList.toMutableList()
+
+        // when
+        val result = detailService.getTimeCapsuleDetail(capsuleId, userId)
+
+        // then
+        assertEquals(capsuleId, result.id)
+        assertEquals("캡슐 제목", result.title)
+        assertEquals(TimeCapsuleStatus.WRITABLE, result.status)
+        assertEquals(true, result.isLiked)
+        assertEquals(1, result.likeCount)
+        assertEquals(2, result.participantCount)
+        assertNotNull(result.remainingTime)
+        assertEquals(1, result.remainingTime?.days)
+    }
+
+    @Test
+    fun `캡슐이 WAITING_OPEN 상태일 때, 상세 정보를 정확히 반환한다`() {
+        // given
+        val now = LocalDateTime.now()
+        val userId = 2L
+        val capsuleId = 20L
+        val user = mockk<User>()
+        val capsule = mockk<TimeCapsule>()
+        val like = mockk<TimeCapsuleLike>()
+        val users = listOf(mockk<TimeCapsuleUser>())
+        val likes = listOf(mockk<TimeCapsuleLike>().apply { every { isLiked } returns true })
+
+        every { capsuleReader.getById(capsuleId) } returns capsule
+        every { userReader.getById(userId) } returns user
+        every { likeReader.findByUserAndCapsule(user, capsule) } returns like
+        every { like.isLiked } returns true
+
+        every { capsule.id } returns capsuleId
+        every { capsule.title } returns "대기 중 캡슐"
+        every { capsule.subtitle } returns "기다림의 미학"
+        every { capsule.closedAt } returns now.minusDays(2)
+        every { capsule.openAt } returns now.plusDays(3)
+        every { capsule.timeCapsuleUsers } returns users.toMutableList()
+        every { capsule.timeCapsuleLikes } returns likes.toMutableList()
+
+        // when
+        val result = detailService.getTimeCapsuleDetail(capsuleId, userId)
+
+        // then
+        assertEquals(TimeCapsuleStatus.WAITING_OPEN, result.status)
+        assertEquals(2, result.remainingTime?.days)
+        assertEquals(23, result.remainingTime?.hours)
+        assertEquals(59, result.remainingTime?.minutes)
+    }
+
+    @Test
+    fun `캡슐이 OPENED 상태일 때, 상세 정보를 정확히 반환한다`() {
+        // given
+        val now = LocalDateTime.now()
+        val capsuleId = 30L
+        val capsule = mockk<TimeCapsule>()
+        val users = listOf(mockk<TimeCapsuleUser>())
+        val likes = listOf(mockk<TimeCapsuleLike>().apply { every { isLiked } returns false })
+
+        every { capsuleReader.getById(capsuleId) } returns capsule
+        every { capsule.id } returns capsuleId
+        every { capsule.title } returns "오픈된 캡슐"
+        every { capsule.subtitle } returns "이제 읽어보세요"
+        every { capsule.closedAt } returns now.minusDays(3)
+        every { capsule.openAt } returns now.minusDays(2)
+        every { capsule.timeCapsuleUsers } returns users.toMutableList()
+        every { capsule.timeCapsuleLikes } returns likes.toMutableList()
+
+        // when
+        val result = detailService.getTimeCapsuleDetail(capsuleId, null) // 비로그인 사용자
+
+        // then
+        assertEquals(TimeCapsuleStatus.OPENED, result.status)
+        assertEquals(null, result.isLiked)
+        assertEquals(now.minusDays(2).toLocalDate(), result.remainingTime?.openDate)
+    }
+}

--- a/src/test/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleServiceTest.kt
+++ b/src/test/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleServiceTest.kt
@@ -1,43 +1,49 @@
 package com.yapp.lettie.api.timecapsule.service
 
 import com.yapp.lettie.api.timecapsule.service.dto.CreateTimeCapsulePayload
+import com.yapp.lettie.api.timecapsule.service.reader.TimeCapsuleLikeReader
 import com.yapp.lettie.api.timecapsule.service.reader.TimeCapsuleReader
+import com.yapp.lettie.api.timecapsule.service.writer.TimeCapsuleLikeWriter
 import com.yapp.lettie.api.timecapsule.service.writer.TimeCapsuleWriter
 import com.yapp.lettie.api.user.service.reader.UserReader
 import com.yapp.lettie.common.error.ErrorMessages
 import com.yapp.lettie.common.exception.ApiErrorException
 import com.yapp.lettie.domain.timecapsule.entity.TimeCapsule
+import com.yapp.lettie.domain.timecapsule.entity.TimeCapsuleLike
 import com.yapp.lettie.domain.timecapsule.entity.TimeCapsuleUser
 import com.yapp.lettie.domain.timecapsule.entity.vo.AccessType
 import com.yapp.lettie.domain.user.entity.User
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.spyk
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.mockito.kotlin.any
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
 import java.time.LocalDateTime
 
 class TimeCapsuleServiceTest {
-    private val userReader: UserReader = mock()
-    private val capsuleWriter: TimeCapsuleWriter = mock()
-    private val capsuleReader: TimeCapsuleReader = mock()
+    private val userReader: UserReader = mockk()
+    private val capsuleWriter: TimeCapsuleWriter = mockk()
+    private val capsuleReader: TimeCapsuleReader = mockk()
+    private val capsuleLikeWriter: TimeCapsuleLikeWriter = mockk()
+    private val capsuleLikeReader: TimeCapsuleLikeReader = mockk()
 
     private lateinit var timeCapsuleService: TimeCapsuleService
 
     @BeforeEach
     fun setUp() {
-        timeCapsuleService = TimeCapsuleService(userReader, capsuleWriter, capsuleReader)
+        timeCapsuleService =
+            TimeCapsuleService(userReader, capsuleWriter, capsuleReader, capsuleLikeWriter, capsuleLikeReader)
     }
 
     @Test
     fun `타임캡슐을 생성하면 저장소에 저장된다`() {
         // given
         val userId = 1L
-        val user = mock<User>()
+        val user = mockk<User>(relaxed = true)
         val payload =
             CreateTimeCapsulePayload(
                 title = "title",
@@ -48,18 +54,18 @@ class TimeCapsuleServiceTest {
             )
 
         val dummyCapsule =
-            mock<TimeCapsule> {
-                on { id } doReturn 123L
+            mockk<TimeCapsule> {
+                every { id } returns 123L
             }
 
-        whenever(userReader.getById(userId)).thenReturn(user)
-        whenever(capsuleWriter.save(any())).thenReturn(dummyCapsule)
+        every { userReader.getById(userId) } returns user
+        every { capsuleWriter.save(any()) } returns dummyCapsule
 
         // when
         val capsuleId = timeCapsuleService.createTimeCapsule(userId, payload)
 
         // then
-        verify(capsuleWriter).save(any())
+        verify { capsuleWriter.save(any()) }
         assertThat(capsuleId).isEqualTo(123L)
     }
 
@@ -68,22 +74,22 @@ class TimeCapsuleServiceTest {
         // given
         val userId = 1L
         val capsuleId = 99L
-        val user = mock<User> { on { id } doReturn userId }
+        val user = mockk<User>(relaxed = true) { every { id } returns userId }
         val capsule =
-            mock<TimeCapsule> {
-                on { timeCapsuleUsers } doReturn mutableListOf()
-                on { closedAt } doReturn LocalDateTime.now().plusDays(1)
+            mockk<TimeCapsule>(relaxed = true) {
+                every { timeCapsuleUsers } returns mutableListOf()
+                every { closedAt } returns LocalDateTime.now().plusDays(1)
             }
 
-        whenever(userReader.getById(userId)).thenReturn(user)
-        whenever(capsuleReader.getById(capsuleId)).thenReturn(capsule)
+        every { userReader.getById(userId) } returns user
+        every { capsuleReader.getById(capsuleId) } returns capsule
 
         // when
         timeCapsuleService.joinTimeCapsule(userId, capsuleId)
 
         // then
-        verify(capsule).addUser(any())
-        verify(user).addTimeCapsuleUser(any())
+        verify { capsule.addUser(any()) }
+        verify { user.addTimeCapsuleUser(any()) }
     }
 
     @Test
@@ -91,24 +97,23 @@ class TimeCapsuleServiceTest {
         // given
         val userId = 1L
         val capsuleId = 99L
-        val user = mock<User> { on { id } doReturn userId }
-        val existing = mock<TimeCapsuleUser> { on { this.user } doReturn user }
+        val user = mockk<User> { every { id } returns userId }
+        val capsule = mockk<TimeCapsule>(relaxed = true)
 
-        val capsule =
-            mock<TimeCapsule> {
-                on { timeCapsuleUsers } doReturn mutableListOf(existing)
-                on { closedAt } doReturn LocalDateTime.now().plusDays(1)
-            }
+        val existing = TimeCapsuleUser.of(user, capsule)
 
-        whenever(userReader.getById(userId)).thenReturn(user)
-        whenever(capsuleReader.getById(capsuleId)).thenReturn(capsule)
+        every { userReader.getById(userId) } returns user
+        every { capsuleReader.getById(capsuleId) } returns capsule
+        every { capsule.timeCapsuleUsers } returns mutableListOf(existing)
+        every { capsule.closedAt } returns LocalDateTime.now().plusDays(1)
 
-        // when & then
+        // when
         val exception =
             assertThrows<ApiErrorException> {
                 timeCapsuleService.joinTimeCapsule(userId, capsuleId)
             }
 
+        // then
         assertThat(exception.error.message).isEqualTo(ErrorMessages.ALREADY_JOINED.message)
     }
 
@@ -117,15 +122,15 @@ class TimeCapsuleServiceTest {
         // given
         val userId = 1L
         val capsuleId = 100L
-        val user = mock<User> { on { id } doReturn userId }
+        val user = mockk<User> { every { id } returns userId }
         val capsule =
-            mock<TimeCapsule> {
-                on { timeCapsuleUsers } doReturn mutableListOf()
-                on { closedAt } doReturn LocalDateTime.now().minusMinutes(1) // 마감 지남
+            mockk<TimeCapsule> {
+                every { timeCapsuleUsers } returns mutableListOf()
+                every { closedAt } returns LocalDateTime.now().minusMinutes(1)
             }
 
-        whenever(userReader.getById(userId)).thenReturn(user)
-        whenever(capsuleReader.getById(capsuleId)).thenReturn(capsule)
+        every { userReader.getById(userId) } returns user
+        every { capsuleReader.getById(capsuleId) } returns capsule
 
         // when & then
         val exception =
@@ -133,6 +138,80 @@ class TimeCapsuleServiceTest {
                 timeCapsuleService.joinTimeCapsule(userId, capsuleId)
             }
 
+        // then
         assertThat(exception.error.message).isEqualTo(ErrorMessages.CLOSED_TIME_CAPSULE.message)
+    }
+
+    @Test
+    fun `좋아요가 없으면 새로 생성되고 true가 반환된다`() {
+        // given
+        val userId = 1L
+        val capsuleId = 10L
+        val user = mockk<User>()
+        val capsule = mockk<TimeCapsule>()
+        val likeSlot = slot<TimeCapsuleLike>()
+
+        every { userReader.getById(userId) } returns user
+        every { capsuleReader.getById(capsuleId) } returns capsule
+        every { capsuleLikeReader.findByUserAndCapsule(user, capsule) } returns null
+        every { capsuleLikeWriter.save(capture(likeSlot)) } answers { likeSlot.captured }
+
+        // when
+        val result = timeCapsuleService.toggleLike(userId, capsuleId)
+
+        // then
+        assertThat(result).isTrue()
+        assertThat(likeSlot.isCaptured).isTrue()
+        assertThat(likeSlot.captured.isLiked).isTrue()
+        assertThat(likeSlot.captured.user).isEqualTo(user)
+        assertThat(likeSlot.captured.timeCapsule).isEqualTo(capsule)
+    }
+
+    @Test
+    fun `좋아요가 이미 되어 있으면 isLiked를 false로 변경하고 false를 반환한다`() {
+        // given
+        val userId = 1L
+        val capsuleId = 20L
+        val user = mockk<User>()
+        val capsule = mockk<TimeCapsule>()
+        val existingLike = spyk(TimeCapsuleLike.of(user, capsule))
+        existingLike.isLiked = true
+
+        every { userReader.getById(userId) } returns user
+        every { capsuleReader.getById(capsuleId) } returns capsule
+        every { capsuleLikeReader.findByUserAndCapsule(user, capsule) } returns existingLike
+        every { capsuleLikeWriter.save(existingLike) } returns existingLike
+
+        // when
+        val result = timeCapsuleService.toggleLike(userId, capsuleId)
+
+        // then
+        assertThat(result).isFalse()
+        assertThat(existingLike.isLiked).isFalse()
+        verify { capsuleLikeWriter.save(existingLike) }
+    }
+
+    @Test
+    fun `좋아요가 취소된 상태면 다시 true로 바꾸고 true를 반환한다`() {
+        // given
+        val userId = 1L
+        val capsuleId = 30L
+        val user = mockk<User>()
+        val capsule = mockk<TimeCapsule>()
+        val existingLike = spyk(TimeCapsuleLike.of(user, capsule))
+        existingLike.isLiked = false
+
+        every { userReader.getById(userId) } returns user
+        every { capsuleReader.getById(capsuleId) } returns capsule
+        every { capsuleLikeReader.findByUserAndCapsule(user, capsule) } returns existingLike
+        every { capsuleLikeWriter.save(existingLike) } returns existingLike
+
+        // when
+        val result = timeCapsuleService.toggleLike(userId, capsuleId)
+
+        // then
+        assertThat(result).isTrue()
+        assertThat(existingLike.isLiked).isTrue()
+        verify { capsuleLikeWriter.save(existingLike) }
     }
 }

--- a/src/test/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleServiceTest.kt
+++ b/src/test/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleServiceTest.kt
@@ -14,30 +14,33 @@ import com.yapp.lettie.domain.timecapsule.entity.TimeCapsuleUser
 import com.yapp.lettie.domain.timecapsule.entity.vo.AccessType
 import com.yapp.lettie.domain.user.entity.User
 import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
 import java.time.LocalDateTime
 
+@ExtendWith(MockKExtension::class)
 class TimeCapsuleServiceTest {
-    private val userReader: UserReader = mockk()
-    private val capsuleWriter: TimeCapsuleWriter = mockk()
-    private val capsuleReader: TimeCapsuleReader = mockk()
-    private val capsuleLikeWriter: TimeCapsuleLikeWriter = mockk()
-    private val capsuleLikeReader: TimeCapsuleLikeReader = mockk()
+    @MockK lateinit var userReader: UserReader
 
-    private lateinit var timeCapsuleService: TimeCapsuleService
+    @MockK lateinit var capsuleWriter: TimeCapsuleWriter
 
-    @BeforeEach
-    fun setUp() {
-        timeCapsuleService =
-            TimeCapsuleService(userReader, capsuleWriter, capsuleReader, capsuleLikeWriter, capsuleLikeReader)
-    }
+    @MockK lateinit var capsuleReader: TimeCapsuleReader
+
+    @MockK lateinit var capsuleLikeWriter: TimeCapsuleLikeWriter
+
+    @MockK lateinit var capsuleLikeReader: TimeCapsuleLikeReader
+
+    @InjectMockKs
+    lateinit var timeCapsuleService: TimeCapsuleService
 
     @Test
     fun `타임캡슐을 생성하면 저장소에 저장된다`() {


### PR DESCRIPTION
## 📌 Related Issue

> [!NOTE]
> 관련된 이슈 번호를 적어주세요.

- Close #36 

## 🚀 Description

> [!NOTE]
> 작업한 내용을 간략히 적어주세요.

### api
- 타임캡슐 좋아요 API 구현
    - toggle api로 구현해서 좋아요랑 좋아요 취소 둘 다 api 한 곳에서 진행하도록 하였습니다.
    - 좋아요 삭제/생성을 반복하면 db에 무리가 갈 것 같아서 soft delete 방식으로 진행하기 위해 is_liked 컬럼 추가하였습니다.
- 타임캡슐 상세보기 API 구현
    - TODO: 편지 도메인 구현되면 편지수도 추가
    - TODO: 편지 개수에 따라 다르게 mp4 파일 내려주기
- test 코드 mockito -> mockk

### 기타
- swagger/* 에서 *이 그대로 문자열로 filtering되어서 정규표현식 추가하였습니다.
- 404 (잘못된 엔드포인트 접근), 405 (not allowed method)에 대해서 따로 예외 핸들러 추가해서 처리되지 않은 예외에 잡히지 않도록 하였습니다. -> 추후 flowise 다시 적용할 때 알림 오지 않도록 하기 위함

## 📸 Screenshot
> [!NOTE]
> 변경 사항을 보여주는 스크린샷(또는 GIF)을 첨부해 주세요.

<img width="266" height="515" alt="image" src="https://github.com/user-attachments/assets/2a7ab540-ddc6-4b11-ac06-2a328d3b012f" />
여기서 남은 날짜 표시하기 day, hour, minute 따로 던져주는데 괜찮겠죠?

## 📢 Notes

> [!NOTE]
> 추가적인 설명이나 참고 사항을 작성해 주세요.

```text

```
