### PR TITLE
feat(#62): 타임캡슐 리스트 조회 inviteCode 응답 추가

### DIFF
--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/TimeCapsuleDetailApiController.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/TimeCapsuleDetailApiController.kt
@@ -15,7 +15,6 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -37,12 +36,12 @@ class TimeCapsuleDetailApiController(
     @GetMapping("/my")
     override fun getMyTimeCapsules(
         @LoginUser userInfo: UserInfoPayload,
-        @RequestParam limit: Int,
+        pageable: Pageable,
     ): ResponseEntity<ApiResponse<List<TimeCapsuleSummaryResponse>>> =
         ResponseEntity.ok(
             ApiResponse.success(
                 timeCapsuleDetailService
-                    .getMyTimeCapsules(userInfo.id, limit)
+                    .getMyTimeCapsules(userInfo.id, pageable)
                     .timeCapsules
                     .map { TimeCapsuleSummaryResponse.from(it) },
             ),
@@ -50,12 +49,12 @@ class TimeCapsuleDetailApiController(
 
     @GetMapping("/popular")
     override fun getPopularTimeCapsules(
-        @RequestParam limit: Int,
+        pageable: Pageable,
     ): ResponseEntity<ApiResponse<List<TimeCapsuleSummaryResponse>>> =
         ResponseEntity.ok(
             ApiResponse.success(
                 timeCapsuleDetailService
-                    .getPopularTimeCapsules(limit)
+                    .getPopularTimeCapsules(pageable)
                     .timeCapsules
                     .map { TimeCapsuleSummaryResponse.from(it) },
             ),

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/response/TimeCapsuleSummaryResponse.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/response/TimeCapsuleSummaryResponse.kt
@@ -8,6 +8,8 @@ import io.swagger.v3.oas.annotations.media.Schema
 data class TimeCapsuleSummaryResponse(
     @Schema(description = "타임캡슐 ID", example = "1")
     val id: Long,
+    @Schema(description = "타임캡슐 고유 식별자(공유 링크용)", example = "abc123xy")
+    val inviteCode: String,
     @Schema(description = "타임캡슐 제목", example = "2025 새해 타임캡슐")
     val title: String,
     @Schema(description = "참여 인원 수", example = "4")
@@ -25,6 +27,7 @@ data class TimeCapsuleSummaryResponse(
         fun from(dto: TimeCapsuleSummaryDto): TimeCapsuleSummaryResponse =
             TimeCapsuleSummaryResponse(
                 id = dto.id,
+                inviteCode = dto.inviteCode,
                 title = dto.title,
                 participantCount = dto.participantCount,
                 letterCount = dto.letterCount,

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/swagger/TimeCapsuleDetailSwagger.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/swagger/TimeCapsuleDetailSwagger.kt
@@ -42,7 +42,7 @@ interface TimeCapsuleDetailSwagger {
         description = """
             [메인페이지 내가 만든 캡슐 조회 호출 방식]
             1. 로그인 시에만 내가 만든 캡슐을 조회할 수 있다.
-            2. limit을 10으로 지정하여 메인페이지 내가 만든 캡슐을 조회한다.
+            2. size를 10으로 지정하여 메인페이지 내가 만든 캡슐을 조회한다.
             3. 정렬 방식은 생성일자 (최근)순으로 정렬하여 반환한다.
 
             [응답 구조]
@@ -51,16 +51,33 @@ interface TimeCapsuleDetailSwagger {
             - OPENED인 경우 오픈 날짜와 '오픈 완료'를 반환한다.
         """,
     )
+    @Parameters(
+        Parameter(
+            name = "page",
+            description = "페이지 번호 (0부터 시작)",
+            `in` = ParameterIn.QUERY,
+        ),
+        Parameter(
+            name = "size",
+            description = "페이지 크기",
+            `in` = ParameterIn.QUERY,
+        ),
+        Parameter(
+            name = "sort",
+            description = "정렬 조건 (예: id,desc 또는 id,asc)",
+            `in` = ParameterIn.QUERY,
+        ),
+    )
     fun getMyTimeCapsules(
         userInfo: UserInfoPayload,
-        @Parameter(description = "불러올 개수 (default: 10)") limit: Int = 10,
+        @ParameterObject pageable: Pageable,
     ): ResponseEntity<ApiResponse<List<TimeCapsuleSummaryResponse>>>
 
     @Operation(
         summary = "<< 보류 >> 편지 수 인기 캡슐 조회 (비로그인 가능)",
         description = """
             [탐색페이지 인기 캡슐 조회 호출 방식]
-            1. limit을 12로 지정하여 탐색페이지 인기 캡슐을 조회한다.
+            1. size를 12로 지정하여 탐색페이지 인기 캡슐을 조회한다.
             2. <더보기> 버튼을 눌렀을 때 limit을 60으로 넘겨서 인기 캡슐을 조회한다.
             3. 정렬 방식은 편지 수 -> 생성일자 (최근)순으로 정렬하여 반환한다.
 
@@ -70,8 +87,25 @@ interface TimeCapsuleDetailSwagger {
             - OPENED인 경우 오픈 날짜와 '오픈 완료'를 반환한다.
         """,
     )
+    @Parameters(
+        Parameter(
+            name = "page",
+            description = "페이지 번호 (0부터 시작)",
+            `in` = ParameterIn.QUERY,
+        ),
+        Parameter(
+            name = "size",
+            description = "페이지 크기",
+            `in` = ParameterIn.QUERY,
+        ),
+        Parameter(
+            name = "sort",
+            description = "정렬 조건 (예: id,desc 또는 id,asc)",
+            `in` = ParameterIn.QUERY,
+        ),
+    )
     fun getPopularTimeCapsules(
-        @Parameter(description = "불러올 개수 (default: 12)") limit: Int = 12,
+        @ParameterObject pageable: Pageable,
     ): ResponseEntity<ApiResponse<List<TimeCapsuleSummaryResponse>>>
 
     @Operation(

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailService.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailService.kt
@@ -11,7 +11,7 @@ import com.yapp.lettie.api.timecapsule.service.reader.TimeCapsuleReader
 import com.yapp.lettie.api.timecapsule.service.reader.TimeCapsuleUserReader
 import com.yapp.lettie.domain.timecapsule.entity.TimeCapsule
 import org.springframework.data.domain.Page
-import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 
@@ -60,15 +60,13 @@ class TimeCapsuleDetailService(
 
     fun getMyTimeCapsules(
         userId: Long,
-        limit: Int,
+        pageable: Pageable,
     ): TimeCapsuleSummariesDto {
-        val pageable = PageRequest.of(0, limit)
         val capsules = timeCapsuleReader.getMyTimeCapsules(userId, pageable)
         return getTimeCapsuleSummaries(capsules, LocalDateTime.now())
     }
 
-    fun getPopularTimeCapsules(limit: Int): TimeCapsuleSummariesDto {
-        val pageable = PageRequest.of(0, limit)
+    fun getPopularTimeCapsules(pageable: Pageable): TimeCapsuleSummariesDto {
         val capsules = timeCapsuleReader.getPopularTimeCapsules(pageable)
         return getTimeCapsuleSummaries(capsules, LocalDateTime.now())
     }

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/dto/TimeCapsuleSummariesDto.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/dto/TimeCapsuleSummariesDto.kt
@@ -22,6 +22,7 @@ data class TimeCapsuleSummariesDto(
                 capsules.content.map { capsule ->
                     TimeCapsuleSummaryDto(
                         id = capsule.id,
+                        inviteCode = capsule.inviteCode,
                         title = capsule.title,
                         participantCount = participantCountMap[capsule.id] ?: 0,
                         letterCount = letterCountMap[capsule.id] ?: 0,

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/dto/TimeCapsuleSummaryDto.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/dto/TimeCapsuleSummaryDto.kt
@@ -2,6 +2,7 @@ package com.yapp.lettie.api.timecapsule.service.dto
 
 data class TimeCapsuleSummaryDto(
     val id: Long,
+    val inviteCode: String,
     val title: String,
     val participantCount: Int,
     val letterCount: Int,

--- a/src/main/resources/db/migration/V20250804_1__change_batch.sql
+++ b/src/main/resources/db/migration/V20250804_1__change_batch.sql
@@ -1,0 +1,9 @@
+RENAME TABLE batch_job_instance TO BATCH_JOB_INSTANCE;
+RENAME TABLE batch_job_execution TO BATCH_JOB_EXECUTION;
+RENAME TABLE batch_job_execution_params TO BATCH_JOB_EXECUTION_PARAMS;
+RENAME TABLE batch_step_execution TO BATCH_STEP_EXECUTION;
+RENAME TABLE batch_step_execution_context TO BATCH_STEP_EXECUTION_CONTEXT;
+RENAME TABLE batch_job_execution_context TO BATCH_JOB_EXECUTION_CONTEXT;
+RENAME TABLE batch_step_execution_seq TO BATCH_STEP_EXECUTION_SEQ;
+RENAME TABLE batch_job_execution_seq TO BATCH_JOB_EXECUTION_SEQ;
+RENAME TABLE batch_job_seq TO BATCH_JOB_SEQ;

--- a/src/test/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailServiceTest.kt
+++ b/src/test/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailServiceTest.kt
@@ -264,14 +264,15 @@ class TimeCapsuleDetailServiceTest {
                     closedAt = now.plusDays(2),
                 ),
             )
+
         val pageable = PageRequest.of(0, 2)
-        val page = PageImpl(capsules, pageable, 2)
+        val page = PageImpl(capsules, pageable, 0)
         every { capsuleReader.getMyTimeCapsules(userId, any()) } returns page
         every { timeCapsuleUserReader.getParticipantCountMap(listOf(1L, 2L)) } returns mapOf(1L to 3, 2L to 5)
         every { letterReader.getLetterCountMap(listOf(1L, 2L)) } returns mapOf(1L to 10, 2L to 15)
 
         // when
-        val result = detailService.getMyTimeCapsules(userId, limit = 2)
+        val result = detailService.getMyTimeCapsules(userId, pageable)
 
         // then
         assertEquals(2, result.timeCapsules.size)
@@ -298,7 +299,7 @@ class TimeCapsuleDetailServiceTest {
         every { letterReader.getLetterCountMap(emptyList()) } returns emptyMap()
 
         // when
-        val result = detailService.getMyTimeCapsules(userId, limit = 2)
+        val result = detailService.getMyTimeCapsules(userId, pageable)
 
         // then
         assertTrue(result.timeCapsules.isEmpty())
@@ -339,7 +340,7 @@ class TimeCapsuleDetailServiceTest {
         every { letterReader.getLetterCountMap(listOf(100L, 101L)) } returns mapOf(100L to 20, 101L to 30)
 
         // when
-        val result = detailService.getPopularTimeCapsules(limit = 2)
+        val result = detailService.getPopularTimeCapsules(pageable)
 
         // then
         assertEquals(2, result.timeCapsules.size)
@@ -362,7 +363,7 @@ class TimeCapsuleDetailServiceTest {
         every { letterReader.getLetterCountMap(emptyList()) } returns emptyMap()
 
         // when
-        val result = detailService.getPopularTimeCapsules(limit = 2)
+        val result = detailService.getPopularTimeCapsules(pageable)
 
         // then
         assertTrue(result.timeCapsules.isEmpty())


### PR DESCRIPTION
## 📌 Related Issue

> [!NOTE]
> 관련된 이슈 번호를 적어주세요.

- Close #62 

## 🚀 Description

> [!NOTE]
> 작업한 내용을 간략히 적어주세요.

```text
타임캡슐 리스트 조회 inviteCode 응답 추가
```

## 📸 Screenshot
> [!NOTE]
> 변경 사항을 보여주는 스크린샷(또는 GIF)을 첨부해 주세요.

## 📢 Notes

> [!NOTE]
> 추가적인 설명이나 참고 사항을 작성해 주세요.

```text

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 타임캡슐 요약 정보에 초대 코드(inviteCode) 표시가 추가되었습니다.

* **기능 개선**
  * 내 타임캡슐 및 인기 타임캡슐 목록 조회 시 페이징(Pageable) 방식이 적용되어, 페이지 및 정렬 등 다양한 페이징 옵션을 사용할 수 있습니다.

* **문서화**
  * API 문서에 페이징 파라미터(page, size, sort) 관련 설명이 추가되었습니다.

* **기타**
  * 배치 관련 데이터베이스 테이블명이 대문자로 일괄 변경되었습니다.
  * 관련 테스트 코드가 페이징 방식에 맞게 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->