### PR TITLE
feat(#66): 탐색과 검색에 정적인 정렬 추가

### DIFF
--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/swagger/TimeCapsuleDetailSwagger.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/swagger/TimeCapsuleDetailSwagger.kt
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.constraints.NotBlank
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RequestMapping
 
@@ -22,8 +23,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 interface TimeCapsuleDetailSwagger {
     @Operation(
         summary = "타임캡슐 상세 조회",
-        description =
-            """
+        description = """
         캡슐의 기본 정보와 오픈일시, 참여자 수, 좋아요 여부, 상태 및 남은 시간을 조회합니다.
         로그인하지 않은 사용자도 접근 가능하며, 로그인 사용자일 경우 좋아요 여부(liked)가 포함됩니다.
 
@@ -111,15 +111,17 @@ interface TimeCapsuleDetailSwagger {
 
     @Operation(
         summary = "타임캡슐 리스트 조회 (비로그인 가능)",
-        description =
-            """
+        description = """
         타임캡슐 리스트를 조회합니다. 타입에 따라 필터링이 가능합니다.
-        페이지네이션과 정렬 기능을 지원합니다.
+        페이지네이션 기능을 지원합니다.
 
         <타입별 필터링>
         - WRITABLE: 작성 가능한 캡슐
         - WAITING_OPEN: 오픈 대기 중인 캡슐
         - OPENED: 오픈된 캡슐
+
+        <정렬 방식>
+        - 편지 많은 순서로 정렬, 편지 수가 동일하면 생성일이 최근인 순서로 정렬
         """,
     )
     @Parameters(
@@ -131,25 +133,22 @@ interface TimeCapsuleDetailSwagger {
         Parameter(
             name = "size",
             description = "페이지 크기",
-            `in` = ParameterIn.QUERY,
-        ),
-        Parameter(
-            name = "sort",
-            description = "정렬 조건 (예: id,desc 또는 id,asc)",
             `in` = ParameterIn.QUERY,
         ),
     )
     fun exploreTimeCapsules(
         type: TimeCapsuleStatus?,
-        @ParameterObject pageable: Pageable,
+        @Parameter(hidden = true) @PageableDefault(size = 20, page = 0) pageable: Pageable,
     ): ResponseEntity<ApiResponse<TimeCapsuleSummariesResponse>>
 
     @Operation(
         summary = "타임캡슐 검색 (비로그인 가능)",
-        description =
-            """
-        타임캡슐을 키워드로 검색합니다. 페이지네이션과 정렬 기능을 지원합니다.
+        description = """
+        타임캡슐을 키워드로 검색합니다. 페이지네이션 기능을 지원합니다.
         검색어는 타임캡슐 제목을 포함합니다.
+
+        <정렬 방식>
+        - 편지 많은 순서로 정렬, 편지 수가 동일하면 생성일이 최근인 순서로 정렬
         """,
     )
     @Parameters(
@@ -163,14 +162,9 @@ interface TimeCapsuleDetailSwagger {
             description = "페이지 크기",
             `in` = ParameterIn.QUERY,
         ),
-        Parameter(
-            name = "sort",
-            description = "정렬 조건 (예: id,desc 또는 id,asc)",
-            `in` = ParameterIn.QUERY,
-        ),
     )
     fun searchTimeCapsules(
         @NotBlank keyword: String,
-        @ParameterObject pageable: Pageable,
+        @Parameter(hidden = true) @PageableDefault(size = 20, page = 0) pageable: Pageable,
     ): ResponseEntity<ApiResponse<TimeCapsuleSummariesResponse>>
 }

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/reader/TimeCapsuleReader.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/reader/TimeCapsuleReader.kt
@@ -54,6 +54,5 @@ class TimeCapsuleReader(
     fun searchTimeCapsules(
         keyword: String,
         pageable: Pageable,
-    ): Page<TimeCapsule> =
-        timeCapsuleRepository.findTimeCapsuleByTitleContainingAndAccessType(keyword, AccessType.PUBLIC, pageable)
+    ): Page<TimeCapsule> = timeCapsuleRepository.findTimeCapsulesByTitle(keyword, AccessType.PUBLIC, pageable)
 }

--- a/src/main/kotlin/com/yapp/lettie/domain/timecapsule/repository/TimeCapsuleCustomerRepository.kt
+++ b/src/main/kotlin/com/yapp/lettie/domain/timecapsule/repository/TimeCapsuleCustomerRepository.kt
@@ -1,6 +1,7 @@
 package com.yapp.lettie.domain.timecapsule.repository
 
 import com.yapp.lettie.domain.timecapsule.entity.TimeCapsule
+import com.yapp.lettie.domain.timecapsule.entity.vo.AccessType
 import com.yapp.lettie.domain.timecapsule.entity.vo.TimeCapsuleStatus
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -10,6 +11,12 @@ interface TimeCapsuleCustomerRepository {
     fun getTimeCapsulesByStatus(
         type: TimeCapsuleStatus?,
         now: LocalDateTime,
+        pageable: Pageable,
+    ): Page<TimeCapsule>
+
+    fun findTimeCapsulesByTitle(
+        title: String,
+        accessType: AccessType,
         pageable: Pageable,
     ): Page<TimeCapsule>
 }

--- a/src/main/kotlin/com/yapp/lettie/domain/timecapsule/repository/TimeCapsuleCustomerRepositoryImpl.kt
+++ b/src/main/kotlin/com/yapp/lettie/domain/timecapsule/repository/TimeCapsuleCustomerRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.yapp.lettie.domain.timecapsule.repository
 
 import com.querydsl.core.BooleanBuilder
+import com.querydsl.core.types.OrderSpecifier
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.yapp.lettie.config.limit
 import com.yapp.lettie.domain.letter.entity.QLetter.letter
@@ -16,6 +17,7 @@ import java.time.LocalDateTime
 class TimeCapsuleCustomerRepositoryImpl(
     private val queryFactory: JPAQueryFactory,
 ) : TimeCapsuleCustomerRepository {
+    @Suppress("ktlint:standard:no-consecutive-comments")
     override fun getTimeCapsulesByStatus(
         type: TimeCapsuleStatus?,
         now: LocalDateTime,
@@ -41,7 +43,7 @@ class TimeCapsuleCustomerRepositoryImpl(
             }
         }
 
-        val result =
+        val query =
             queryFactory
                 .select(timeCapsule)
                 .from(timeCapsule)
@@ -49,10 +51,36 @@ class TimeCapsuleCustomerRepositoryImpl(
                 .on(letter.timeCapsule.id.eq(timeCapsule.id))
                 .where(timeCapsule.accessType.eq(AccessType.PUBLIC).and(builder))
                 .groupBy(timeCapsule.id)
-                .orderBy(letter.count().desc(), timeCapsule.createdAt.desc())
-                .offset(pageable.offset)
-                .limit(pageable.pageSize)
-                .fetch()
+
+        // 기본 정렬: 편지 수 내림차순, 생성일 내림차순
+        val orderSpecifiers = orderByLetterCount()
+
+        // todo: 동적 정렬 추가
+/*
+        for (sort in pageable.sort) {
+            val orderSpecifier =
+                when (sort.property) {
+                    "createdAt" -> {
+                        if (sort.isAscending) timeCapsule.createdAt.asc() else timeCapsule.createdAt.desc()
+                    }
+                    "closedAt" -> {
+                        if (sort.isAscending) timeCapsule.closedAt.asc() else timeCapsule.closedAt.desc()
+                    }
+                    "openAt" -> {
+                        if (sort.isAscending) timeCapsule.openAt.asc() else timeCapsule.openAt.desc()
+                    }
+                    else -> continue // 지원하지 않는 정렬 속성은 무시
+                }
+            orderSpecifiers.add(orderSpecifier)
+        }
+*/
+
+        query
+            .orderBy(*orderSpecifiers.toTypedArray())
+            .offset(pageable.offset)
+            .limit(pageable.pageSize)
+
+        val result = query.fetch()
 
         val countQuery =
             queryFactory
@@ -60,10 +88,61 @@ class TimeCapsuleCustomerRepositoryImpl(
                 .from(timeCapsule)
                 .leftJoin(letter)
                 .on(letter.timeCapsule.id.eq(timeCapsule.id))
-                .where(timeCapsule.accessType.eq(AccessType.PUBLIC))
+                .where(timeCapsule.accessType.eq(AccessType.PUBLIC).and(builder))
 
         return PageableExecutionUtils.getPage(result, pageable) {
             countQuery.fetchOne() ?: 0L
         }
+    }
+
+    override fun findTimeCapsulesByTitle(
+        title: String,
+        accessType: AccessType,
+        pageable: Pageable,
+    ): Page<TimeCapsule> {
+        val query =
+            queryFactory
+                .select(timeCapsule)
+                .from(timeCapsule)
+                .leftJoin(letter)
+                .on(letter.timeCapsule.id.eq(timeCapsule.id))
+                .where(
+                    timeCapsule.title
+                        .contains(title)
+                        .and(timeCapsule.accessType.eq(accessType)),
+                ).groupBy(timeCapsule.id)
+
+        // 기본 정렬: 편지 수 내림차순, ID 내림차순
+        val orderSpecifiers = orderByLetterCount()
+
+        query
+            .orderBy(*orderSpecifiers.toTypedArray())
+            .offset(pageable.offset)
+            .limit(pageable.pageSize)
+
+        val result = query.fetch()
+
+        val countQuery =
+            queryFactory
+                .select(timeCapsule.countDistinct())
+                .from(timeCapsule)
+                .leftJoin(letter)
+                .on(letter.timeCapsule.id.eq(timeCapsule.id))
+                .where(
+                    timeCapsule.title
+                        .containsIgnoreCase(title)
+                        .and(timeCapsule.accessType.eq(accessType)),
+                )
+
+        return PageableExecutionUtils.getPage(result, pageable) {
+            countQuery.fetchOne() ?: 0L
+        }
+    }
+
+    private fun orderByLetterCount(): MutableList<OrderSpecifier<*>> {
+        val orderSpecifiers = mutableListOf<OrderSpecifier<*>>()
+        orderSpecifiers.add(letter.count().desc())
+        orderSpecifiers.add(timeCapsule.id.desc())
+        return orderSpecifiers
     }
 }

--- a/src/main/kotlin/com/yapp/lettie/domain/timecapsule/repository/TimeCapsuleRepository.kt
+++ b/src/main/kotlin/com/yapp/lettie/domain/timecapsule/repository/TimeCapsuleRepository.kt
@@ -1,7 +1,6 @@
 package com.yapp.lettie.domain.timecapsule.repository
 
 import com.yapp.lettie.domain.timecapsule.entity.TimeCapsule
-import com.yapp.lettie.domain.timecapsule.entity.vo.AccessType
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
@@ -40,10 +39,4 @@ interface TimeCapsuleRepository :
         @Param("previousCheckTime") previousCheckTime: LocalDateTime,
         @Param("now") now: LocalDateTime,
     ): List<TimeCapsule>
-
-    fun findTimeCapsuleByTitleContainingAndAccessType(
-        title: String,
-        accessType: AccessType,
-        pageable: Pageable,
-    ): Page<TimeCapsule>
 }


### PR DESCRIPTION
## 📌 Related Issue

> [!NOTE]
> 관련된 이슈 번호를 적어주세요.

- Close #66 

## 🚀 Description

> [!NOTE]
> 작업한 내용을 간략히 적어주세요.

```text
편지 많은 순서로 정렬, 편지 수가 동일하면 생성일이 최근인 순서로 정렬

```

## 📸 Screenshot
> [!NOTE]
> 변경 사항을 보여주는 스크린샷(또는 GIF)을 첨부해 주세요.

## 📢 Notes

> [!NOTE]
> 추가적인 설명이나 참고 사항을 작성해 주세요.

```text

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 타임캡슐 검색 시 제목으로 검색하는 기능이 개선되었습니다.
  * 검색 및 리스트 조회 시 기본 정렬 방식(편지 수 내림차순, 생성일 내림차순)이 명확하게 안내됩니다.

* **Bug Fixes**
  * Swagger 문서에서 정렬 관련 잘못된 파라미터가 제거되고, 페이지네이션 기본값이 명확히 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->