### PR TITLE
feat(#67): 첫 오픈 기능 구현

### DIFF
--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/response/TimeCapsuleDetailResponse.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/response/TimeCapsuleDetailResponse.kt
@@ -35,10 +35,12 @@ data class TimeCapsuleDetailResponse(
     val inviteCode: String,
     @Schema(description = "구슬 영상 URL", example = "https://example.com/bead-video.mp4")
     val beadVideoUrl: String,
+    @Schema(description = "첫 오픈 여부", example = "true")
+    val isFirstOpen: Boolean,
 ) {
     companion object {
-        fun from(dto: TimeCapsuleDetailDto): TimeCapsuleDetailResponse {
-            return TimeCapsuleDetailResponse(
+        fun from(dto: TimeCapsuleDetailDto): TimeCapsuleDetailResponse =
+            TimeCapsuleDetailResponse(
                 id = dto.id,
                 title = dto.title,
                 subtitle = dto.subtitle,
@@ -61,7 +63,7 @@ data class TimeCapsuleDetailResponse(
                 isMine = dto.isMine,
                 inviteCode = dto.inviteCode,
                 beadVideoUrl = dto.beadVideoUrl,
+                isFirstOpen = dto.isFirstOpen,
             )
-        }
     }
 }

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailService.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailService.kt
@@ -11,7 +11,7 @@ import com.yapp.lettie.api.timecapsule.service.dto.TimeCapsuleSummariesDto
 import com.yapp.lettie.api.timecapsule.service.reader.TimeCapsuleLikeReader
 import com.yapp.lettie.api.timecapsule.service.reader.TimeCapsuleReader
 import com.yapp.lettie.api.timecapsule.service.reader.TimeCapsuleUserReader
-import com.yapp.lettie.api.timecapsule.service.reader.TimeCapsuleUserWriter
+import com.yapp.lettie.api.timecapsule.service.writer.TimeCapsuleUserWriter
 import com.yapp.lettie.domain.timecapsule.entity.TimeCapsule
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailService.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailService.kt
@@ -11,6 +11,7 @@ import com.yapp.lettie.api.timecapsule.service.dto.TimeCapsuleSummariesDto
 import com.yapp.lettie.api.timecapsule.service.reader.TimeCapsuleLikeReader
 import com.yapp.lettie.api.timecapsule.service.reader.TimeCapsuleReader
 import com.yapp.lettie.api.timecapsule.service.reader.TimeCapsuleUserReader
+import com.yapp.lettie.api.timecapsule.service.reader.TimeCapsuleUserWriter
 import com.yapp.lettie.domain.timecapsule.entity.TimeCapsule
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -23,6 +24,7 @@ class TimeCapsuleDetailService(
     private val timeCapsuleReader: TimeCapsuleReader,
     private val timeCapsuleLikeReader: TimeCapsuleLikeReader,
     private val timeCapsuleUserReader: TimeCapsuleUserReader,
+    private val timeCapsuleUserWriter: TimeCapsuleUserWriter,
     private val letterReader: LetterReader,
 ) {
     fun getTimeCapsuleDetail(
@@ -37,10 +39,17 @@ class TimeCapsuleDetailService(
         val remainingTime = RemainingTimeDto.fromStatus(status, now, capsule.openAt, capsule.closedAt)
         val likeCount = timeCapsuleLikeReader.getLikeCount(capsuleId)
         val participantCount = timeCapsuleUserReader.getParticipantCount(capsuleId)
+        val timeCapsuleUser = timeCapsuleUserReader.getTimeCapsuleUser(capsuleId, userId)
+        val isFirstOpen = !timeCapsuleUser.isOpened
         val letterCount = letterReader.getLetterCountByCapsuleId(capsule.id)
         val isMine = capsule.creator.id == userId
         val objectKey = getBeadObjectKey(letterCount)
         val beadVideoUrl = fileService.generatePresignedDownloadUrlByObjectKey(objectKey).url
+
+        if (isFirstOpen) {
+            timeCapsuleUser.updateOpened()
+            timeCapsuleUserWriter.save(timeCapsuleUser)
+        }
 
         return TimeCapsuleDetailDto(
             id = capsule.id,
@@ -57,6 +66,7 @@ class TimeCapsuleDetailService(
             isMine = isMine,
             inviteCode = capsule.inviteCode,
             beadVideoUrl = beadVideoUrl,
+            isFirstOpen = isFirstOpen,
         )
     }
 

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/dto/TimeCapsuleDetailDto.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/dto/TimeCapsuleDetailDto.kt
@@ -18,4 +18,5 @@ data class TimeCapsuleDetailDto(
     val isMine: Boolean,
     val inviteCode: String,
     val beadVideoUrl: String,
+    val isFirstOpen: Boolean,
 )

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/reader/TimeCapsuleUserReader.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/reader/TimeCapsuleUserReader.kt
@@ -1,5 +1,8 @@
 package com.yapp.lettie.api.timecapsule.service.reader
 
+import com.yapp.lettie.common.error.ErrorMessages
+import com.yapp.lettie.common.exception.ApiErrorException
+import com.yapp.lettie.domain.timecapsule.entity.TimeCapsuleUser
 import com.yapp.lettie.domain.timecapsule.repository.TimeCapsuleUserRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -9,35 +12,41 @@ class TimeCapsuleUserReader(
     private val timeCapsuleUserRepository: TimeCapsuleUserRepository,
 ) {
     @Transactional(readOnly = true)
-    fun getParticipantCount(capsuleId: Long): Int {
-        return timeCapsuleUserRepository.countByTimeCapsuleId(capsuleId)
-    }
+    fun getParticipantCount(capsuleId: Long): Int = timeCapsuleUserRepository.countByTimeCapsuleId(capsuleId)
 
     @Transactional(readOnly = true)
-    fun getParticipantCountMap(capsuleIds: List<Long>): Map<Long, Int> {
-        return timeCapsuleUserRepository.getCountGroupedByCapsuleIds(capsuleIds)
+    fun getParticipantCountMap(capsuleIds: List<Long>): Map<Long, Int> =
+        timeCapsuleUserRepository
+            .getCountGroupedByCapsuleIds(capsuleIds)
             .associate { row ->
                 val capsuleId = row[0] as Long
                 val count = (row[1] as Long).toInt()
                 capsuleId to count
             }
-    }
 
     @Transactional(readOnly = true)
     fun findEmailsByCapsuleId(capsuleId: Long): List<String> =
-        timeCapsuleUserRepository.findAllByTimeCapsuleId(capsuleId)
+        timeCapsuleUserRepository
+            .findAllByTimeCapsuleId(capsuleId)
             .map { it.user.email }
 
     @Transactional(readOnly = true)
     fun getEmailsGroupByCapsuleId(capsuleIds: List<Long>): Map<Long, List<String>> =
-        timeCapsuleUserRepository.findAllByCapsuleIdsFetchUser(capsuleIds)
+        timeCapsuleUserRepository
+            .findAllByCapsuleIdsFetchUser(capsuleIds)
             .groupBy({ it.timeCapsule.id }, { it.user.email })
 
     @Transactional(readOnly = true)
     fun hasUserJoinedCapsule(
         userId: Long,
         capsuleId: Long,
-    ): Boolean {
-        return timeCapsuleUserRepository.existsByUserIdAndTimeCapsuleId(userId, capsuleId)
-    }
+    ): Boolean = timeCapsuleUserRepository.existsByUserIdAndTimeCapsuleId(userId, capsuleId)
+
+    @Transactional(readOnly = true)
+    fun getTimeCapsuleUser(
+        capsuleId: Long,
+        userId: Long,
+    ): TimeCapsuleUser =
+        timeCapsuleUserRepository.findByUserIdAndTimeCapsuleId(userId, capsuleId)
+            ?: throw ApiErrorException(ErrorMessages.NOT_JOINED_TIME_CAPSULE)
 }

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/reader/TimeCapsuleUserWriter.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/reader/TimeCapsuleUserWriter.kt
@@ -1,0 +1,16 @@
+package com.yapp.lettie.api.timecapsule.service.reader
+
+import com.yapp.lettie.domain.timecapsule.entity.TimeCapsuleUser
+import com.yapp.lettie.domain.timecapsule.repository.TimeCapsuleUserRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class TimeCapsuleUserWriter(
+    private val timeCapsuleUserRepository: TimeCapsuleUserRepository,
+) {
+    @Transactional
+    fun save(timeCapsuleUser: TimeCapsuleUser) {
+        timeCapsuleUserRepository.save(timeCapsuleUser)
+    }
+}

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/writer/TimeCapsuleUserWriter.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/writer/TimeCapsuleUserWriter.kt
@@ -1,4 +1,4 @@
-package com.yapp.lettie.api.timecapsule.service.reader
+package com.yapp.lettie.api.timecapsule.service.writer
 
 import com.yapp.lettie.domain.timecapsule.entity.TimeCapsuleUser
 import com.yapp.lettie.domain.timecapsule.repository.TimeCapsuleUserRepository

--- a/src/main/kotlin/com/yapp/lettie/domain/timecapsule/entity/TimeCapsuleUser.kt
+++ b/src/main/kotlin/com/yapp/lettie/domain/timecapsule/entity/TimeCapsuleUser.kt
@@ -33,11 +33,14 @@ class TimeCapsuleUser(
         fun of(
             user: User,
             timeCapsule: TimeCapsule,
-        ): TimeCapsuleUser {
-            return TimeCapsuleUser(
+        ): TimeCapsuleUser =
+            TimeCapsuleUser(
                 user = user,
                 timeCapsule = timeCapsule,
             )
-        }
+    }
+
+    fun updateOpened() {
+        this.isOpened = true
     }
 }

--- a/src/main/kotlin/com/yapp/lettie/domain/timecapsule/repository/TimeCapsuleUserRepository.kt
+++ b/src/main/kotlin/com/yapp/lettie/domain/timecapsule/repository/TimeCapsuleUserRepository.kt
@@ -37,4 +37,9 @@ interface TimeCapsuleUserRepository : JpaRepository<TimeCapsuleUser, Long> {
         userId: Long,
         capsuleId: Long,
     ): Boolean
+
+    fun findByUserIdAndTimeCapsuleId(
+        userId: Long,
+        capsuleId: Long,
+    ): TimeCapsuleUser?
 }

--- a/src/test/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailServiceTest.kt
+++ b/src/test/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailServiceTest.kt
@@ -8,7 +8,7 @@ import com.yapp.lettie.api.timecapsule.service.dto.SearchTimeCapsulesPayload
 import com.yapp.lettie.api.timecapsule.service.reader.TimeCapsuleLikeReader
 import com.yapp.lettie.api.timecapsule.service.reader.TimeCapsuleReader
 import com.yapp.lettie.api.timecapsule.service.reader.TimeCapsuleUserReader
-import com.yapp.lettie.api.timecapsule.service.reader.TimeCapsuleUserWriter
+import com.yapp.lettie.api.timecapsule.service.writer.TimeCapsuleUserWriter
 import com.yapp.lettie.domain.timecapsule.entity.TimeCapsule
 import com.yapp.lettie.domain.timecapsule.entity.TimeCapsuleLike
 import com.yapp.lettie.domain.timecapsule.entity.TimeCapsuleUser


### PR DESCRIPTION
## 📌 Related Issue

> [!NOTE]
> 관련된 이슈 번호를 적어주세요.

- Close #67 

## 🚀 Description

> [!NOTE]
> 작업한 내용을 간략히 적어주세요.

```text
최초 오픈 여부를 확인할 수 있게 응답값 추가
```

## 📸 Screenshot
> [!NOTE]
> 변경 사항을 보여주는 스크린샷(또는 GIF)을 첨부해 주세요.

## 📢 Notes

> [!NOTE]
> 추가적인 설명이나 참고 사항을 작성해 주세요.

```text

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 타임캡슐 상세 정보에 사용자의 첫 오픈 여부(isFirstOpen) 표시가 추가되었습니다.

* **버그 수정**
  * 타임캡슐을 처음 오픈할 때, 사용자 상태가 자동으로 갱신되어 이후에는 첫 오픈이 아니라고 표시됩니다.

* **테스트**
  * 첫 오픈 상태와 관련된 서비스 동작 및 예외 상황에 대한 테스트가 추가 및 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->