### PR TITLE
infra(#105): 개발계 도메인 cors 허용

### DIFF
--- a/src/main/kotlin/com/yapp/lettie/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/yapp/lettie/config/SecurityConfig.kt
@@ -34,6 +34,7 @@ class SecurityConfig {
             listOf(
                 "https://api-dev.lettie.me",
                 "https://lettie.me",
+                "https://dev.lettie.me",
                 "https://www.lettie.me",
                 "https://localhost:3000",
                 "http://localhost:3000",


### PR DESCRIPTION
## 📌 Related Issue

> [!NOTE]
> 관련된 이슈 번호를 적어주세요.

- Close #105

## 🚀 Description

> [!NOTE]
> 작업한 내용을 간략히 적어주세요.

```text
개발계 도메인 cors 허용
```

## 📸 Screenshot
> [!NOTE]
> 변경 사항을 보여주는 스크린샷(또는 GIF)을 첨부해 주세요.

## 📢 Notes

> [!NOTE]
> 추가적인 설명이나 참고 사항을 작성해 주세요.

```text

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - CORS 허용 도메인에 https://dev.lettie.me 추가. 이제 해당 도메인에서 웹 앱이 API에 접근할 때 교차 출처 요청이 차단되지 않으며, 인증·헤더·메서드 동작은 기존과 동일합니다. 다른 도메인 및 동작에는 변화가 없습니다. 이로써 브라우저 기반 기능이 정상적으로 호출되고, 개발용 배포 주소에서 페이지 로드와 상호작용 시 오류 메시지가 감소합니다. 서버 보안 정책의 나머지 설정은 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->