### PR TITLE
feat(#109): oauth 에 state param 추가

### DIFF
--- a/src/main/kotlin/com/yapp/lettie/api/auth/client/GoogleClient.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/auth/client/GoogleClient.kt
@@ -20,7 +20,6 @@ class GoogleClient(
     fun login(
         authorizationCode: String,
         redirectUrl: String,
-        state: String? = null,
     ): AuthUserInfoDto {
         val tokenRequestParams =
             LinkedMultiValueMap<String, String>().apply {
@@ -29,7 +28,6 @@ class GoogleClient(
                 add("client_secret", authoGoogleClient.clientSecret)
                 add("redirect_uri", redirectUrl)
                 add("code", URLDecoder.decode(authorizationCode, StandardCharsets.UTF_8))
-                state?.let { add("state", it) }
             }
 
         val tokenResponse =

--- a/src/main/kotlin/com/yapp/lettie/api/auth/client/GoogleClient.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/auth/client/GoogleClient.kt
@@ -29,7 +29,7 @@ class GoogleClient(
                 add("client_secret", authoGoogleClient.clientSecret)
                 add("redirect_uri", redirectUrl)
                 add("code", URLDecoder.decode(authorizationCode, StandardCharsets.UTF_8))
-                add("state", state)
+                state?.let { add("state", it) }
             }
 
         val tokenResponse =

--- a/src/main/kotlin/com/yapp/lettie/api/auth/client/GoogleClient.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/auth/client/GoogleClient.kt
@@ -20,6 +20,7 @@ class GoogleClient(
     fun login(
         authorizationCode: String,
         redirectUrl: String,
+        state: String? = null,
     ): AuthUserInfoDto {
         val tokenRequestParams =
             LinkedMultiValueMap<String, String>().apply {
@@ -28,6 +29,7 @@ class GoogleClient(
                 add("client_secret", authoGoogleClient.clientSecret)
                 add("redirect_uri", redirectUrl)
                 add("code", URLDecoder.decode(authorizationCode, StandardCharsets.UTF_8))
+                add("state", state)
             }
 
         val tokenResponse =

--- a/src/main/kotlin/com/yapp/lettie/api/auth/client/NaverClient.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/auth/client/NaverClient.kt
@@ -24,7 +24,7 @@ class NaverClient(
                 add("grant_type", authNaverClient.grantType)
                 add("client_id", authNaverClient.clientId)
                 add("client_secret", authNaverClient.clientSecret)
-                add("state", state)
+                state?.let { add("state", it) }
                 add("code", authorizationCode)
             }
 

--- a/src/main/kotlin/com/yapp/lettie/api/auth/client/NaverClient.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/auth/client/NaverClient.kt
@@ -15,13 +15,16 @@ class NaverClient(
     private val authNaverClient: AuthNaverConfig,
     private val restClientUtil: RestClientUtil,
 ) {
-    fun login(authorizationCode: String): AuthUserInfoDto {
+    fun login(
+        authorizationCode: String,
+        state: String?,
+    ): AuthUserInfoDto {
         val tokenRequestParams =
             LinkedMultiValueMap<String, String>().apply {
                 add("grant_type", authNaverClient.grantType)
                 add("client_id", authNaverClient.clientId)
                 add("client_secret", authNaverClient.clientSecret)
-                add("state", authNaverClient.state)
+                add("state", state)
                 add("code", authorizationCode)
             }
 

--- a/src/main/kotlin/com/yapp/lettie/api/auth/controller/AuthApiController.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/auth/controller/AuthApiController.kt
@@ -46,10 +46,13 @@ class AuthApiController(
     }
 
     @GetMapping("/oauth/google")
-    override fun googleAuth(redirectUrl: String): ResponseEntity<ApiResponse<OAuthUrlResponse>> =
+    override fun googleAuth(
+        redirectUrl: String,
+        state: String?,
+    ): ResponseEntity<ApiResponse<OAuthUrlResponse>> =
         ResponseEntity.ok().body(
             ApiResponse.success(
-                OAuthUrlResponse(authService.getGoogleLoginUrl(redirectUrl)),
+                OAuthUrlResponse(authService.getGoogleLoginUrl(redirectUrl, state)),
             ),
         )
 
@@ -62,7 +65,7 @@ class AuthApiController(
             throw ApiErrorException(ErrorMessages.REDIRECT_URL_REQUIRED)
         }
 
-        val jwtTokenDto = authService.googleLogin(request.authorizationCode, request.redirectUrl)
+        val jwtTokenDto = authService.googleLogin(request.authorizationCode, request.redirectUrl, request.state)
         cookieComponent.setAccessTokenCookie(jwtTokenDto, response)
 
         return ResponseEntity.ok().body(
@@ -73,10 +76,13 @@ class AuthApiController(
     }
 
     @GetMapping("/oauth/naver")
-    override fun naverAuth(redirectUrl: String): ResponseEntity<ApiResponse<OAuthUrlResponse>> =
+    override fun naverAuth(
+        redirectUrl: String,
+        state: String?,
+    ): ResponseEntity<ApiResponse<OAuthUrlResponse>> =
         ResponseEntity.ok().body(
             ApiResponse.success(
-                OAuthUrlResponse(authService.getNaverLoginUrl(redirectUrl)),
+                OAuthUrlResponse(authService.getNaverLoginUrl(redirectUrl, state)),
             ),
         )
 
@@ -85,7 +91,7 @@ class AuthApiController(
         @RequestBody request: AuthorizationRequest,
         response: HttpServletResponse,
     ): ResponseEntity<ApiResponse<JwtTokenResponse>> {
-        val jwtTokenDto = authService.naverLogin(request.authorizationCode)
+        val jwtTokenDto = authService.naverLogin(request.authorizationCode, request.state)
         cookieComponent.setAccessTokenCookie(jwtTokenDto, response)
 
         return ResponseEntity.ok().body(

--- a/src/main/kotlin/com/yapp/lettie/api/auth/controller/AuthApiController.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/auth/controller/AuthApiController.kt
@@ -65,7 +65,7 @@ class AuthApiController(
             throw ApiErrorException(ErrorMessages.REDIRECT_URL_REQUIRED)
         }
 
-        val jwtTokenDto = authService.googleLogin(request.authorizationCode, request.redirectUrl, request.state)
+        val jwtTokenDto = authService.googleLogin(request.authorizationCode, request.redirectUrl)
         cookieComponent.setAccessTokenCookie(jwtTokenDto, response)
 
         return ResponseEntity.ok().body(

--- a/src/main/kotlin/com/yapp/lettie/api/auth/controller/AuthSwagger.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/auth/controller/AuthSwagger.kt
@@ -29,6 +29,8 @@ interface AuthSwagger {
     fun googleAuth(
         @Schema(description = "구글 로그인 후 리다이렉트될 URL (URL 인코딩 필요)")
         redirectUrl: String,
+        @Schema(description = "구글 로그인 후 상태값 (선택사항)", example = "state")
+        state: String? = null,
     ): ResponseEntity<ApiResponse<OAuthUrlResponse>>
 
     @Operation(
@@ -44,6 +46,8 @@ interface AuthSwagger {
     fun naverAuth(
         @Schema(description = "네이버 로그인 후 리다이렉트될 URL (URL 인코딩 필요)")
         redirectUrl: String,
+        @Schema(description = "네이버 로그인 후 상태값 (선택사항)", example = "state")
+        state: String? = null,
     ): ResponseEntity<ApiResponse<OAuthUrlResponse>>
 
     @Operation(

--- a/src/main/kotlin/com/yapp/lettie/api/auth/controller/request/AuthorizationRequest.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/auth/controller/request/AuthorizationRequest.kt
@@ -7,4 +7,6 @@ data class AuthorizationRequest(
     val authorizationCode: String,
     @Schema(description = "redirect URL (URL 인코딩 X)")
     val redirectUrl: String?,
+    @Schema(description = "구글 로그인 후 상태값 (선택사항)", example = "state")
+    val state: String? = null,
 )

--- a/src/main/kotlin/com/yapp/lettie/api/auth/controller/request/AuthorizationRequest.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/auth/controller/request/AuthorizationRequest.kt
@@ -7,6 +7,6 @@ data class AuthorizationRequest(
     val authorizationCode: String,
     @Schema(description = "redirect URL (URL 인코딩 X)")
     val redirectUrl: String?,
-    @Schema(description = "구글 로그인 후 상태값 (선택사항)", example = "state")
+    @Schema(description = "로그인 후 상태값 (선택사항)", example = "state")
     val state: String? = null,
 )

--- a/src/main/kotlin/com/yapp/lettie/api/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/auth/service/AuthService.kt
@@ -24,9 +24,15 @@ class AuthService(
 ) {
     fun getKakaoLoginUrl(url: String): String = authKakaoConfig.oauthUrl(url)
 
-    fun getGoogleLoginUrl(url: String): String = authGoogleConfig.oauthUrl(url)
+    fun getGoogleLoginUrl(
+        url: String,
+        state: String?,
+    ): String = authGoogleConfig.oauthUrl(url, state)
 
-    fun getNaverLoginUrl(url: String): String = authNaverConfig.oauthUrl(url)
+    fun getNaverLoginUrl(
+        url: String,
+        state: String?,
+    ): String = authNaverConfig.oauthUrl(url, state)
 
     fun kakaoLogin(
         authorizationCode: String,
@@ -43,8 +49,9 @@ class AuthService(
     fun googleLogin(
         authorizationCode: String,
         redirectUrl: String,
+        state: String?,
     ): JwtTokenDto {
-        val authUserInfoDto = googleClient.login(authorizationCode, redirectUrl)
+        val authUserInfoDto = googleClient.login(authorizationCode, redirectUrl, state)
 
         val user = userLoginProcessor.loginOrRegister(authUserInfoDto, OAuthProvider.GOOGLE)
         val token: String = jwtComponent.create(user.id, user.role.key)
@@ -52,8 +59,11 @@ class AuthService(
         return JwtTokenDto.of(token, user)
     }
 
-    fun naverLogin(authorizationCode: String): JwtTokenDto {
-        val authUserInfoDto = naverClient.login(authorizationCode)
+    fun naverLogin(
+        authorizationCode: String,
+        state: String?,
+    ): JwtTokenDto {
+        val authUserInfoDto = naverClient.login(authorizationCode, state)
 
         val user = userLoginProcessor.loginOrRegister(authUserInfoDto, OAuthProvider.NAVER)
         val token: String = jwtComponent.create(user.id, user.role.key)

--- a/src/main/kotlin/com/yapp/lettie/api/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/auth/service/AuthService.kt
@@ -49,9 +49,8 @@ class AuthService(
     fun googleLogin(
         authorizationCode: String,
         redirectUrl: String,
-        state: String?,
     ): JwtTokenDto {
-        val authUserInfoDto = googleClient.login(authorizationCode, redirectUrl, state)
+        val authUserInfoDto = googleClient.login(authorizationCode, redirectUrl)
 
         val user = userLoginProcessor.loginOrRegister(authUserInfoDto, OAuthProvider.GOOGLE)
         val token: String = jwtComponent.create(user.id, user.role.key)

--- a/src/main/kotlin/com/yapp/lettie/config/AuthGoogleConfig.kt
+++ b/src/main/kotlin/com/yapp/lettie/config/AuthGoogleConfig.kt
@@ -31,11 +31,18 @@ class AuthGoogleConfig {
     fun oauthUrl(
         url: String,
         state: String?,
-    ): String =
-        authorizationUri +
-            "?client_id=$clientId" +
-            "&redirect_uri=$url" +
-            "&state=$state" +
-            "&response_type=code" +
-            "&scope=${scope.replace(",", "%20")}"
+    ): String {
+        val baseUrl =
+            authorizationUri +
+                "?client_id=$clientId" +
+                "&redirect_uri=$url" +
+                "&response_type=code" +
+                "&scope=${scope.replace(",", "%20")}"
+
+        return if (state != null) {
+            "$baseUrl&state=$state"
+        } else {
+            baseUrl
+        }
+    }
 }

--- a/src/main/kotlin/com/yapp/lettie/config/AuthGoogleConfig.kt
+++ b/src/main/kotlin/com/yapp/lettie/config/AuthGoogleConfig.kt
@@ -28,10 +28,14 @@ class AuthGoogleConfig {
 
     var grantType = "authorization_code"
 
-    fun oauthUrl(url: String): String =
+    fun oauthUrl(
+        url: String,
+        state: String?,
+    ): String =
         authorizationUri +
             "?client_id=$clientId" +
             "&redirect_uri=$url" +
+            "&state=$state" +
             "&response_type=code" +
             "&scope=${scope.replace(",", "%20")}"
 }

--- a/src/main/kotlin/com/yapp/lettie/config/AuthNaverConfig.kt
+++ b/src/main/kotlin/com/yapp/lettie/config/AuthNaverConfig.kt
@@ -28,10 +28,17 @@ class AuthNaverConfig {
     fun oauthUrl(
         url: String,
         state: String?,
-    ): String =
-        authorizationUri +
-            "?client_id=$clientId" +
-            "&redirect_uri=$url" +
-            "&response_type=code" +
-            "&state=$state"
+    ): String {
+        val baseUrl =
+            authorizationUri +
+                "?client_id=$clientId" +
+                "&redirect_uri=$url" +
+                "&response_type=code"
+
+        return if (state != null) {
+            "$baseUrl&state=$state"
+        } else {
+            baseUrl
+        }
+    }
 }

--- a/src/main/kotlin/com/yapp/lettie/config/AuthNaverConfig.kt
+++ b/src/main/kotlin/com/yapp/lettie/config/AuthNaverConfig.kt
@@ -23,12 +23,12 @@ class AuthNaverConfig {
     @Value("\${oauth.naver.user-info-uri}")
     lateinit var userInfoUri: String
 
-    @Value("\${oauth.naver.state}")
-    lateinit var state: String
-
     var grantType = "authorization_code"
 
-    fun oauthUrl(url: String): String =
+    fun oauthUrl(
+        url: String,
+        state: String?,
+    ): String =
         authorizationUri +
             "?client_id=$clientId" +
             "&redirect_uri=$url" +

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -43,4 +43,4 @@ logging:
 cookie:
   secure: false
   same-site: Strict
-  domain: #비어있게
+  domain: "" #비어있게

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,7 +44,6 @@ oauth:
     authorization-uri: https://nid.naver.com/oauth2.0/authorize
     token-uri: https://nid.naver.com/oauth2.0/token
     user-info-uri: https://openapi.naver.com/v1/nid/me
-    state: ${NAVER_STATE}
 
 
 jwt:

--- a/src/main/resources/db/migration/V20250820_1__modify_letter_content.sql
+++ b/src/main/resources/db/migration/V20250820_1__modify_letter_content.sql
@@ -1,0 +1,2 @@
+ALTER TABLE letter
+    change column content content text;


### PR DESCRIPTION
## 📌 Related Issue

> [!NOTE]
> 관련된 이슈 번호를 적어주세요.

- Close #109 

## 🚀 Description

> [!NOTE]
> 작업한 내용을 간략히 적어주세요.

```text
oauth 에 state param 을 추가해
프론트가 활용할 수 있게 한다.
```

## 📸 Screenshot
> [!NOTE]
> 변경 사항을 보여주는 스크린샷(또는 GIF)을 첨부해 주세요.

## 📢 Notes

> [!NOTE]
> 추가적인 설명이나 참고 사항을 작성해 주세요.

```text

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - Google·Naver OAuth 요청에 선택적 state 파라미터 지원. 로그인 URL 생성부터 인증 처리까지 state 전달 가능해졌습니다.
- 문서
  - 인증 관련 API 문서에 state 파라미터 설명 추가.
- 설정/잡무
  - NAVER OAuth의 고정 state 설정 제거 및 로컬 환경 쿠키 도메인 기본값 정리.
- 잡무
  - 편지(content) 컬럼을 TEXT로 변경하는 DB 마이그레이션 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->