### PR TITLE
feat(#108): 타임캡슐 나가기 API 생성 및 Elastic APM 연동

### DIFF
--- a/deployment/prod/docker-compose/docker-compose.blue.yml
+++ b/deployment/prod/docker-compose/docker-compose.blue.yml
@@ -15,6 +15,7 @@ services:
       - docker_compose_backend
     volumes:
       - /var/logs/prod:/logs/prod
+      - /opt/elastic/apm:/opt/elastic/apm:ro
 
 networks:
   docker_compose_backend:

--- a/deployment/prod/docker-compose/docker-compose.green.yml
+++ b/deployment/prod/docker-compose/docker-compose.green.yml
@@ -15,6 +15,7 @@ services:
       - docker_compose_backend
     volumes:
       - /var/logs/prod:/logs/prod
+      - /opt/elastic/apm:/opt/elastic/apm:ro
 
 networks:
   docker_compose_backend:

--- a/src/main/kotlin/com/yapp/lettie/api/ApiPath.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/ApiPath.kt
@@ -23,6 +23,7 @@ enum class ApiPath(
     // 타임캡슐 관련 API
     TIME_CAPSULE_CREATE("/api/v1/capsules", HttpMethod.POST, AuthType.REQUIRED),
     TIME_CAPSULE_JOIN("/api/v1/capsules/{capsuleId}/join", HttpMethod.POST, AuthType.REQUIRED),
+    TIME_CAPSULE_LEAVE("/api/v1/capsules/{capsuleId}/leave", HttpMethod.DELETE, AuthType.REQUIRED),
     TIME_CAPSULE_LIKE("/api/v1/capsules/{capsuleId}/like", HttpMethod.POST, AuthType.REQUIRED),
     TIME_CAPSULE_DETAIL("/api/v1/capsules/{capsuleId}", HttpMethod.GET, AuthType.OPTIONAL),
 

--- a/src/main/kotlin/com/yapp/lettie/api/letter/service/LetterService.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/letter/service/LetterService.kt
@@ -16,6 +16,7 @@ import com.yapp.lettie.common.exception.ApiErrorException
 import com.yapp.lettie.domain.file.entity.LetterFile
 import com.yapp.lettie.domain.letter.entity.Letter
 import com.yapp.lettie.domain.timecapsule.entity.TimeCapsuleUser
+import com.yapp.lettie.domain.timecapsule.entity.vo.TimeCapsuleUserStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
@@ -40,6 +41,8 @@ class LetterService(
         if (capsule.isClosed(LocalDateTime.now())) {
             throw ApiErrorException(ErrorMessages.CLOSED_TIME_CAPSULE)
         }
+
+        validateUserCanJoinByLetter(userId, payload.capsuleId)
 
         val alreadyJoined = timeCapsuleUserReader.hasUserJoinedCapsule(user.id, capsule.id)
         if (!alreadyJoined) {
@@ -108,6 +111,16 @@ class LetterService(
 
         if (capsule.isPrivate() && capsule.timeCapsuleUsers.none { it.user.id == userId }) {
             throw ApiErrorException(ErrorMessages.NOT_JOINED_TIME_CAPSULE)
+        }
+    }
+
+    private fun validateUserCanJoinByLetter(
+        userId: Long,
+        capsuleId: Long,
+    ) {
+        val timeCapsuleUser = timeCapsuleUserReader.getTimeCapsuleUserOrNull(capsuleId, userId)
+        if (timeCapsuleUser != null && timeCapsuleUser.status == TimeCapsuleUserStatus.LEFT) {
+            throw ApiErrorException(ErrorMessages.ALREADY_LEFT_CAPSULE)
         }
     }
 }

--- a/src/main/kotlin/com/yapp/lettie/api/letter/service/LetterService.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/letter/service/LetterService.kt
@@ -118,7 +118,7 @@ class LetterService(
         userId: Long,
         capsuleId: Long,
     ) {
-        val timeCapsuleUser = timeCapsuleUserReader.getTimeCapsuleUserOrNull(capsuleId, userId)
+        val timeCapsuleUser = timeCapsuleUserReader.findTimeCapsuleUser(capsuleId, userId)
         if (timeCapsuleUser != null && timeCapsuleUser.status == TimeCapsuleUserStatus.LEFT) {
             throw ApiErrorException(ErrorMessages.ALREADY_LEFT_CAPSULE)
         }

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/TimeCapsuleApiController.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/TimeCapsuleApiController.kt
@@ -50,6 +50,15 @@ class TimeCapsuleApiController(
         return ResponseEntity.ok(ApiResponse.success(true))
     }
 
+    @DeleteMapping("/{capsuleId}/leave")
+    override fun leave(
+        @LoginUser userInfo: UserInfoPayload,
+        @PathVariable capsuleId: Long,
+    ): ResponseEntity<ApiResponse<Boolean>> {
+        timeCapsuleService.leaveTimeCapsule(userInfo.id, capsuleId)
+        return ResponseEntity.ok(ApiResponse.success(true))
+    }
+
     @Deprecated("편지 작성 시 자동 참여 처리로 인해 더 이상 사용되지 않습니다. 추후 제거 예정입니다.")
     @PostMapping("/{capsuleId}/join")
     override fun join(

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/response/TimeCapsuleDetailResponse.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/response/TimeCapsuleDetailResponse.kt
@@ -32,6 +32,8 @@ data class TimeCapsuleDetailResponse(
     val remainingTime: RemainingTimeResponse?,
     @Schema(description = "내가 만든 타임캡슐 여부", example = "false")
     val isMine: Boolean,
+    @Schema(description = "캡슐 참여 여부", example = "true")
+    val isJoined: Boolean,
     @Schema(description = "타임캡슐 고유 식별자(공유 링크용)", example = "abc123xy")
     val inviteCode: String,
     @Schema(description = "구슬 영상 URL", example = "https://example.com/bead-video.mp4")
@@ -64,6 +66,7 @@ data class TimeCapsuleDetailResponse(
                         )
                     },
                 isMine = dto.isMine,
+                isJoined = dto.isJoined,
                 inviteCode = dto.inviteCode,
                 beadVideoUrl = dto.beadVideoUrl,
                 isFirstOpen = dto.isFirstOpen,

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/swagger/TimeCapsuleSwagger.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/swagger/TimeCapsuleSwagger.kt
@@ -47,4 +47,13 @@ interface TimeCapsuleSwagger {
         userInfo: UserInfoPayload,
         capsuleId: Long,
     ): ResponseEntity<ApiResponse<Boolean>>
+
+    @Operation(
+        summary = "타임캡슐 나가기",
+        description = "참여 중인 타임캡슐에서 나갑니다. 캡슐에서 나가면 재참여는 불가능합니다.",
+    )
+    fun leave(
+        userInfo: UserInfoPayload,
+        capsuleId: Long,
+    ): ResponseEntity<ApiResponse<Boolean>>
 }

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailService.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailService.kt
@@ -46,7 +46,7 @@ class TimeCapsuleDetailService(
 
         val (isFirstOpen, isMine, isJoined) =
             if (userId != null) {
-                val timeCapsuleUser = timeCapsuleUserReader.getTimeCapsuleUserOrNull(capsuleId, userId)
+                val timeCapsuleUser = timeCapsuleUserReader.findTimeCapsuleUser(capsuleId, userId)
                 val firstOpen = timeCapsuleUser?.let { !it.isOpened } ?: false
                 if (firstOpen && timeCapsuleUser != null) {
                     timeCapsuleUser.updateOpened()

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailService.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailService.kt
@@ -44,7 +44,7 @@ class TimeCapsuleDetailService(
         val likeCount = timeCapsuleLikeReader.getLikeCount(capsuleId)
         val participantCount = timeCapsuleUserReader.getParticipantCount(capsuleId)
 
-        val (isFirstOpen, isMine) =
+        val (isFirstOpen, isMine, isJoined) =
             if (userId != null) {
                 val timeCapsuleUser = timeCapsuleUserReader.getTimeCapsuleUserOrNull(capsuleId, userId)
                 val firstOpen = timeCapsuleUser?.let { !it.isOpened } ?: false
@@ -52,9 +52,10 @@ class TimeCapsuleDetailService(
                     timeCapsuleUser.updateOpened()
                     timeCapsuleUserWriter.save(timeCapsuleUser)
                 }
-                firstOpen to (capsule.creator.id == userId)
+                val joined = timeCapsuleUser?.isActive ?: false
+                Triple(firstOpen, capsule.creator.id == userId, joined)
             } else {
-                false to false
+                Triple(false, false, false)
             }
 
         val letterCount = letterReader.getLetterCountByCapsuleId(capsule.id)
@@ -74,6 +75,7 @@ class TimeCapsuleDetailService(
             status = status,
             remainingTime = remainingTime,
             isMine = isMine,
+            isJoined = isJoined,
             inviteCode = capsule.inviteCode,
             beadVideoUrl = beadVideoUrl,
             isFirstOpen = isFirstOpen,

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/dto/TimeCapsuleDetailDto.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/dto/TimeCapsuleDetailDto.kt
@@ -17,6 +17,7 @@ data class TimeCapsuleDetailDto(
     val status: TimeCapsuleStatus,
     val remainingTime: RemainingTimeDto? = null,
     val isMine: Boolean,
+    val isJoined: Boolean,
     val inviteCode: String,
     val beadVideoUrl: String,
     val isFirstOpen: Boolean,

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/reader/TimeCapsuleUserReader.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/reader/TimeCapsuleUserReader.kt
@@ -4,6 +4,7 @@ import com.yapp.lettie.common.error.ErrorMessages
 import com.yapp.lettie.common.exception.ApiErrorException
 import com.yapp.lettie.domain.timecapsule.dto.RecipientRow
 import com.yapp.lettie.domain.timecapsule.entity.TimeCapsuleUser
+import com.yapp.lettie.domain.timecapsule.entity.vo.TimeCapsuleUserStatus
 import com.yapp.lettie.domain.timecapsule.repository.TimeCapsuleUserRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -13,23 +14,18 @@ class TimeCapsuleUserReader(
     private val timeCapsuleUserRepository: TimeCapsuleUserRepository,
 ) {
     @Transactional(readOnly = true)
-    fun getParticipantCount(capsuleId: Long): Int = timeCapsuleUserRepository.countByTimeCapsuleId(capsuleId)
+    fun getParticipantCount(capsuleId: Long): Int =
+        timeCapsuleUserRepository.countByTimeCapsuleIdAndStatus(capsuleId, TimeCapsuleUserStatus.ACTIVE)
 
     @Transactional(readOnly = true)
     fun getParticipantCountMap(capsuleIds: List<Long>): Map<Long, Int> =
         timeCapsuleUserRepository
-            .getCountGroupedByCapsuleIds(capsuleIds)
+            .getCountGroupedByCapsuleIdsAndStatus(capsuleIds, TimeCapsuleUserStatus.ACTIVE)
             .associate { row ->
                 val capsuleId = row[0] as Long
                 val count = (row[1] as Long).toInt()
                 capsuleId to count
             }
-
-    @Transactional(readOnly = true)
-    fun findEmailsByCapsuleId(capsuleId: Long): List<String> =
-        timeCapsuleUserRepository
-            .findAllByTimeCapsuleId(capsuleId)
-            .map { it.user.email }
 
     @Transactional(readOnly = true)
     fun getRecipientsGroupedByCapsuleId(capsuleIds: List<Long>): Map<Long, List<RecipientRow>> {
@@ -42,7 +38,12 @@ class TimeCapsuleUserReader(
     fun hasUserJoinedCapsule(
         userId: Long,
         capsuleId: Long,
-    ): Boolean = timeCapsuleUserRepository.existsByUserIdAndTimeCapsuleId(userId, capsuleId)
+    ): Boolean =
+        timeCapsuleUserRepository.existsByUserIdAndTimeCapsuleIdAndStatus(
+            userId,
+            capsuleId,
+            TimeCapsuleUserStatus.ACTIVE,
+        )
 
     @Transactional(readOnly = true)
     fun getTimeCapsuleUser(

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/reader/TimeCapsuleUserReader.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/reader/TimeCapsuleUserReader.kt
@@ -54,7 +54,7 @@ class TimeCapsuleUserReader(
             ?: throw ApiErrorException(ErrorMessages.NOT_JOINED_TIME_CAPSULE)
 
     @Transactional(readOnly = true)
-    fun getTimeCapsuleUserOrNull(
+    fun findTimeCapsuleUser(
         capsuleId: Long,
         userId: Long,
     ): TimeCapsuleUser? = timeCapsuleUserRepository.findByUserIdAndTimeCapsuleId(userId, capsuleId)

--- a/src/main/kotlin/com/yapp/lettie/common/error/ErrorMessages.kt
+++ b/src/main/kotlin/com/yapp/lettie/common/error/ErrorMessages.kt
@@ -32,6 +32,8 @@ enum class ErrorMessages(
     NOT_JOINED_TIME_CAPSULE(ExtendedHttpStatus.FORBIDDEN, 4_006, "타임캡슐에 참여하지 않았습니다."),
     INVALID_OPEN_AT(ExtendedHttpStatus.BAD_REQUEST, 4_007, "오픈 날짜가 현재 시간 이전입니다."),
     INVALID_CLOSED_AT(ExtendedHttpStatus.BAD_REQUEST, 4_008, "작성 마감 날짜가 오픈 날짜 이후입니다."),
+    NOT_JOINED_CAPSULE(ExtendedHttpStatus.BAD_REQUEST, 4_009, "참여하지 않은 캡슐입니다."),
+    ALREADY_LEFT_CAPSULE(ExtendedHttpStatus.BAD_REQUEST, 4_010, "이미 나간 캡슐입니다."),
 
     // file
     CAN_NOT_GET_PRESIGNED_URL(ExtendedHttpStatus.INTERNAL_SERVER_ERROR, 5_001, "Presigned URL을 가져올 수 없습니다."),

--- a/src/main/kotlin/com/yapp/lettie/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/yapp/lettie/config/SwaggerConfig.kt
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Configuration
 
 @OpenAPIDefinition(
     servers = [
+        Server(url = "https://api.lettie.me", description = "운영 서버"),
         Server(url = "https://api-dev.lettie.me", description = "개발 서버"),
         Server(url = "http://localhost:8080", description = "로컬 서버"),
     ],

--- a/src/main/kotlin/com/yapp/lettie/domain/timecapsule/entity/TimeCapsuleUser.kt
+++ b/src/main/kotlin/com/yapp/lettie/domain/timecapsule/entity/TimeCapsuleUser.kt
@@ -1,10 +1,13 @@
 package com.yapp.lettie.domain.timecapsule.entity
 
 import com.yapp.lettie.domain.BaseEntity
+import com.yapp.lettie.domain.timecapsule.entity.vo.TimeCapsuleUserStatus
 import com.yapp.lettie.domain.user.entity.User
 import jakarta.persistence.Column
 import jakarta.persistence.ConstraintMode
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
 import jakarta.persistence.ForeignKey
 import jakarta.persistence.GeneratedValue
@@ -28,6 +31,9 @@ class TimeCapsuleUser(
     val timeCapsule: TimeCapsule,
     @Column(name = "is_opened", nullable = false)
     var isOpened: Boolean = false,
+    @Column(name = "status", nullable = false)
+    @Enumerated(EnumType.STRING)
+    var status: TimeCapsuleUserStatus = TimeCapsuleUserStatus.ACTIVE,
 ) : BaseEntity() {
     companion object {
         fun of(
@@ -43,4 +49,13 @@ class TimeCapsuleUser(
     fun updateOpened() {
         this.isOpened = true
     }
+
+    fun leave() {
+        this.status = TimeCapsuleUserStatus.LEFT
+    }
+
+    val isActive: Boolean
+        get() = status == TimeCapsuleUserStatus.ACTIVE
+
+    fun canJoinByLetter(): Boolean = status == TimeCapsuleUserStatus.NEVER_JOINED
 }

--- a/src/main/kotlin/com/yapp/lettie/domain/timecapsule/entity/vo/TimeCapsuleUserStatus.kt
+++ b/src/main/kotlin/com/yapp/lettie/domain/timecapsule/entity/vo/TimeCapsuleUserStatus.kt
@@ -1,0 +1,21 @@
+package com.yapp.lettie.domain.timecapsule.entity.vo
+
+enum class TimeCapsuleUserStatus {
+    /**
+     * 한 번도 참여한 적이 없는 상태
+     * 편지 작성을 통해 캡슐에 참여할 수 있음
+     */
+    NEVER_JOINED,
+
+    /**
+     * 현재 캡슐에 참여 중인 상태
+     * 활성 참여자로 카운트됨
+     */
+    ACTIVE,
+
+    /**
+     * 캡슐에서 나간 상태
+     * 편지 작성을 통한 재참여가 불가능함
+     */
+    LEFT,
+}

--- a/src/main/kotlin/com/yapp/lettie/domain/timecapsule/repository/TimeCapsuleCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/yapp/lettie/domain/timecapsule/repository/TimeCapsuleCustomRepositoryImpl.kt
@@ -133,19 +133,17 @@ class TimeCapsuleCustomRepositoryImpl(
                         and(timeCapsule.creator.id.eq(userId))
 
                     MyCapsuleFilter.LIKED ->
-                        and(like.user.id.eq(userId))
+                        and(like.user.id.eq(userId).and(like.isLiked.isTrue))
 
                     MyCapsuleFilter.PARTICIPATING ->
                         and(participant.user.id.eq(userId).and(participant.status.eq(TimeCapsuleUserStatus.ACTIVE)))
 
                     MyCapsuleFilter.ALL ->
                         and(
-                            timeCapsule.creator.id.eq(userId),
+                            timeCapsule.creator.id.eq(userId)
+                                .or(like.user.id.eq(userId).and(like.isLiked.isTrue))
+                                .or(participant.user.id.eq(userId).and(participant.status.eq(TimeCapsuleUserStatus.ACTIVE))),
                         )
-                            .or(like.user.id.eq(userId))
-                            .or(
-                                participant.user.id.eq(userId).and(participant.status.eq(TimeCapsuleUserStatus.ACTIVE)),
-                            )
                 }
             }
 

--- a/src/main/kotlin/com/yapp/lettie/domain/timecapsule/repository/TimeCapsuleCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/yapp/lettie/domain/timecapsule/repository/TimeCapsuleCustomRepositoryImpl.kt
@@ -17,6 +17,7 @@ import com.yapp.lettie.domain.timecapsule.entity.vo.CapsuleSort
 import com.yapp.lettie.domain.timecapsule.entity.vo.MyCapsuleFilter
 import com.yapp.lettie.domain.timecapsule.entity.vo.SortContext
 import com.yapp.lettie.domain.timecapsule.entity.vo.TimeCapsuleStatus
+import com.yapp.lettie.domain.timecapsule.entity.vo.TimeCapsuleUserStatus
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.support.PageableExecutionUtils
@@ -135,14 +136,16 @@ class TimeCapsuleCustomRepositoryImpl(
                         and(like.user.id.eq(userId))
 
                     MyCapsuleFilter.PARTICIPATING ->
-                        and(participant.user.id.eq(userId))
+                        and(participant.user.id.eq(userId).and(participant.status.eq(TimeCapsuleUserStatus.ACTIVE)))
 
                     MyCapsuleFilter.ALL ->
                         and(
-                            timeCapsule.creator.id.eq(userId)
-                                .or(like.user.id.eq(userId))
-                                .or(participant.user.id.eq(userId)),
+                            timeCapsule.creator.id.eq(userId),
                         )
+                            .or(like.user.id.eq(userId))
+                            .or(
+                                participant.user.id.eq(userId).and(participant.status.eq(TimeCapsuleUserStatus.ACTIVE)),
+                            )
                 }
             }
 

--- a/src/main/kotlin/com/yapp/lettie/domain/timecapsule/repository/TimeCapsuleUserCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/yapp/lettie/domain/timecapsule/repository/TimeCapsuleUserCustomRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.querydsl.core.types.Projections
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.yapp.lettie.domain.timecapsule.dto.RecipientRow
 import com.yapp.lettie.domain.timecapsule.entity.QTimeCapsuleUser
+import com.yapp.lettie.domain.timecapsule.entity.vo.TimeCapsuleUserStatus
 import com.yapp.lettie.domain.user.entity.QUser
 
 class TimeCapsuleUserCustomRepositoryImpl(
@@ -24,7 +25,10 @@ class TimeCapsuleUserCustomRepositoryImpl(
             )
             .from(timeCapsuleUser)
             .join(timeCapsuleUser.user, user)
-            .where(timeCapsuleUser.timeCapsule.id.`in`(capsuleIds))
+            .where(
+                timeCapsuleUser.timeCapsule.id.`in`(capsuleIds)
+                    .and(timeCapsuleUser.status.eq(TimeCapsuleUserStatus.ACTIVE)),
+            )
             .fetch()
     }
 }

--- a/src/main/kotlin/com/yapp/lettie/domain/timecapsule/repository/TimeCapsuleUserCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/yapp/lettie/domain/timecapsule/repository/TimeCapsuleUserCustomRepositoryImpl.kt
@@ -11,6 +11,8 @@ class TimeCapsuleUserCustomRepositoryImpl(
     private val queryFactory: JPAQueryFactory,
 ) : TimeCapsuleUserCustomRepository {
     override fun findRecipientsByCapsuleIds(capsuleIds: List<Long>): List<RecipientRow> {
+        if (capsuleIds.isEmpty()) return emptyList()
+
         val timeCapsuleUser = QTimeCapsuleUser.timeCapsuleUser
         val user = QUser.user
 

--- a/src/main/kotlin/com/yapp/lettie/domain/timecapsule/repository/TimeCapsuleUserRepository.kt
+++ b/src/main/kotlin/com/yapp/lettie/domain/timecapsule/repository/TimeCapsuleUserRepository.kt
@@ -1,6 +1,7 @@
 package com.yapp.lettie.domain.timecapsule.repository
 
 import com.yapp.lettie.domain.timecapsule.entity.TimeCapsuleUser
+import com.yapp.lettie.domain.timecapsule.entity.vo.TimeCapsuleUserStatus
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
@@ -8,7 +9,17 @@ import org.springframework.data.repository.query.Param
 interface TimeCapsuleUserRepository : JpaRepository<TimeCapsuleUser, Long>, TimeCapsuleUserCustomRepository {
     fun findAllByTimeCapsuleId(timeCapsuleId: Long): List<TimeCapsuleUser>
 
+    fun findAllByTimeCapsuleIdAndStatus(
+        timeCapsuleId: Long,
+        status: TimeCapsuleUserStatus,
+    ): List<TimeCapsuleUser>
+
     fun countByTimeCapsuleId(capsuleId: Long): Int
+
+    fun countByTimeCapsuleIdAndStatus(
+        capsuleId: Long,
+        status: TimeCapsuleUserStatus,
+    ): Int
 
     @Query(
         """
@@ -22,9 +33,28 @@ interface TimeCapsuleUserRepository : JpaRepository<TimeCapsuleUser, Long>, Time
         @Param("capsuleIds") capsuleIds: List<Long>,
     ): List<Array<Any>>
 
+    @Query(
+        """
+        SELECT tcu.timeCapsule.id, COUNT(tcu)
+        FROM TimeCapsuleUser tcu
+        WHERE tcu.timeCapsule.id IN :capsuleIds AND tcu.status = :status
+        GROUP BY tcu.timeCapsule.id
+    """,
+    )
+    fun getCountGroupedByCapsuleIdsAndStatus(
+        @Param("capsuleIds") capsuleIds: List<Long>,
+        @Param("status") status: TimeCapsuleUserStatus,
+    ): List<Array<Any>>
+
     fun existsByUserIdAndTimeCapsuleId(
         userId: Long,
         capsuleId: Long,
+    ): Boolean
+
+    fun existsByUserIdAndTimeCapsuleIdAndStatus(
+        userId: Long,
+        capsuleId: Long,
+        status: TimeCapsuleUserStatus,
     ): Boolean
 
     fun findByUserIdAndTimeCapsuleId(

--- a/src/main/resources/db/migration/V20250819_1__add_time_capsule_user_status.sql
+++ b/src/main/resources/db/migration/V20250819_1__add_time_capsule_user_status.sql
@@ -1,0 +1,2 @@
+ALTER TABLE time_capsule_user
+    ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE';

--- a/src/test/kotlin/com/yapp/lettie/api/letter/service/LetterServiceTest.kt
+++ b/src/test/kotlin/com/yapp/lettie/api/letter/service/LetterServiceTest.kt
@@ -75,7 +75,7 @@ class LetterServiceTest {
 
         every { timeCapsuleReader.getById(capsuleId) } returns capsule
         every { userReader.getById(userId) } returns user
-        every { timeCapsuleUserReader.getTimeCapsuleUserOrNull(capsuleId, userId) } returns null
+        every { timeCapsuleUserReader.findTimeCapsuleUser(capsuleId, userId) } returns null
         every { timeCapsuleUserReader.hasUserJoinedCapsule(userId, capsuleId) } returns true
         every { letterWriter.save(any()) } returns savedLetter
         every { fileWriter.save(any()) } returns savedFile
@@ -85,7 +85,7 @@ class LetterServiceTest {
 
         // then
         assertEquals(100L, result)
-        verify(exactly = 1) { timeCapsuleUserReader.getTimeCapsuleUserOrNull(capsuleId, userId) }
+        verify(exactly = 1) { timeCapsuleUserReader.findTimeCapsuleUser(capsuleId, userId) }
         verify(exactly = 1) { timeCapsuleUserReader.hasUserJoinedCapsule(userId, capsuleId) }
     }
 
@@ -119,7 +119,7 @@ class LetterServiceTest {
 
         every { timeCapsuleReader.getById(capsuleId) } returns capsule
         every { userReader.getById(userId) } returns user
-        every { timeCapsuleUserReader.getTimeCapsuleUserOrNull(capsuleId, userId) } returns null
+        every { timeCapsuleUserReader.findTimeCapsuleUser(capsuleId, userId) } returns null
         every { timeCapsuleUserReader.hasUserJoinedCapsule(userId, capsuleId) } returns true
         every { letterWriter.save(any()) } returns savedLetter
 
@@ -130,7 +130,7 @@ class LetterServiceTest {
         assertEquals(100L, result)
         verify(exactly = 1) { timeCapsuleReader.getById(capsuleId) }
         verify(exactly = 1) { userReader.getById(userId) }
-        verify(exactly = 1) { timeCapsuleUserReader.getTimeCapsuleUserOrNull(capsuleId, userId) }
+        verify(exactly = 1) { timeCapsuleUserReader.findTimeCapsuleUser(capsuleId, userId) }
         verify(exactly = 1) { timeCapsuleUserReader.hasUserJoinedCapsule(userId, capsuleId) }
         verify(exactly = 1) { letterWriter.save(any()) }
         verify(exactly = 0) { fileWriter.save(any()) }
@@ -202,7 +202,7 @@ class LetterServiceTest {
 
         every { timeCapsuleReader.getById(capsuleId) } returns capsule
         every { userReader.getById(userId) } returns user
-        every { timeCapsuleUserReader.getTimeCapsuleUserOrNull(capsuleId, userId) } returns leftUser
+        every { timeCapsuleUserReader.findTimeCapsuleUser(capsuleId, userId) } returns leftUser
 
         // when & then
         val exception =
@@ -213,7 +213,7 @@ class LetterServiceTest {
         assertEquals(ErrorMessages.ALREADY_LEFT_CAPSULE.message, exception.error.message)
         verify(exactly = 1) { timeCapsuleReader.getById(capsuleId) }
         verify(exactly = 1) { userReader.getById(userId) }
-        verify(exactly = 1) { timeCapsuleUserReader.getTimeCapsuleUserOrNull(capsuleId, userId) }
+        verify(exactly = 1) { timeCapsuleUserReader.findTimeCapsuleUser(capsuleId, userId) }
         verify(exactly = 0) { timeCapsuleUserReader.hasUserJoinedCapsule(any(), any()) }
         verify(exactly = 0) { letterWriter.save(any()) }
         verify(exactly = 0) { fileWriter.save(any()) }

--- a/src/test/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailServiceTest.kt
+++ b/src/test/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailServiceTest.kt
@@ -101,6 +101,7 @@ class TimeCapsuleDetailServiceTest {
         val timeCapsuleUser =
             mockk<TimeCapsuleUser> {
                 every { isOpened } returns false
+                every { isActive } returns true
                 every { updateOpened() } returns Unit
             }
 
@@ -167,6 +168,7 @@ class TimeCapsuleDetailServiceTest {
         val timeCapsuleUser =
             mockk<TimeCapsuleUser> {
                 every { isOpened } returns true // 이미 방문함
+                every { isActive } returns true
             }
 
         every { capsuleReader.getById(capsuleId) } returns capsule
@@ -269,6 +271,7 @@ class TimeCapsuleDetailServiceTest {
         val timeCapsuleUser =
             mockk<TimeCapsuleUser> {
                 every { isOpened } returns true
+                every { isActive } returns true
             }
 
         every { capsuleReader.getById(capsuleId) } returns capsule
@@ -331,6 +334,7 @@ class TimeCapsuleDetailServiceTest {
         val timeCapsuleUser =
             mockk<TimeCapsuleUser> {
                 every { isOpened } returns true
+                every { isActive } returns true
             }
 
         every { capsuleReader.getById(capsuleId) } returns capsule
@@ -401,6 +405,7 @@ class TimeCapsuleDetailServiceTest {
         val timeCapsuleUser =
             mockk<TimeCapsuleUser> {
                 every { isOpened } returns true
+                every { isActive } returns true
             }
 
         every { capsuleReader.getById(capsuleId) } returns capsule

--- a/src/test/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailServiceTest.kt
+++ b/src/test/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailServiceTest.kt
@@ -112,7 +112,7 @@ class TimeCapsuleDetailServiceTest {
             }
         every { likeReader.getLikeCount(capsuleId) } returns 1
         every { timeCapsuleUserReader.getParticipantCount(capsuleId) } returns 2
-        every { timeCapsuleUserReader.getTimeCapsuleUserOrNull(capsuleId, userId) } returns timeCapsuleUser
+        every { timeCapsuleUserReader.findTimeCapsuleUser(capsuleId, userId) } returns timeCapsuleUser
         every { letterReader.getLetterCountByCapsuleId(capsuleId) } returns 3
         every { timeCapsuleUserWriter.save(timeCapsuleUser) } returns Unit
         every {
@@ -175,7 +175,7 @@ class TimeCapsuleDetailServiceTest {
         every { likeReader.findByUserIdAndCapsuleId(userId, capsuleId) } returns null
         every { likeReader.getLikeCount(capsuleId) } returns 0
         every { timeCapsuleUserReader.getParticipantCount(capsuleId) } returns 1
-        every { timeCapsuleUserReader.getTimeCapsuleUserOrNull(capsuleId, userId) } returns timeCapsuleUser
+        every { timeCapsuleUserReader.findTimeCapsuleUser(capsuleId, userId) } returns timeCapsuleUser
         every { letterReader.getLetterCountByCapsuleId(capsuleId) } returns 5
         every {
             fileService.generatePresignedDownloadUrlByObjectKey("CAPSULE/detail_bead0.png")
@@ -278,7 +278,7 @@ class TimeCapsuleDetailServiceTest {
         every { likeReader.findByUserIdAndCapsuleId(userId, capsuleId) } returns null
         every { likeReader.getLikeCount(capsuleId) } returns 0
         every { timeCapsuleUserReader.getParticipantCount(capsuleId) } returns 1
-        every { timeCapsuleUserReader.getTimeCapsuleUserOrNull(capsuleId, userId) } returns timeCapsuleUser
+        every { timeCapsuleUserReader.findTimeCapsuleUser(capsuleId, userId) } returns timeCapsuleUser
         every { letterReader.getLetterCountByCapsuleId(capsuleId) } returns letterCount
         every {
             fileService.generatePresignedDownloadUrlByObjectKey("CAPSULE/detail_bead2.png")
@@ -344,7 +344,7 @@ class TimeCapsuleDetailServiceTest {
             }
         every { likeReader.getLikeCount(capsuleId) } returns 1
         every { timeCapsuleUserReader.getParticipantCount(capsuleId) } returns 2
-        every { timeCapsuleUserReader.getTimeCapsuleUserOrNull(capsuleId, userId) } returns timeCapsuleUser
+        every { timeCapsuleUserReader.findTimeCapsuleUser(capsuleId, userId) } returns timeCapsuleUser
         every { letterReader.getLetterCountByCapsuleId(capsuleId) } returns 3
         every {
             fileService.generatePresignedDownloadUrlByObjectKey("CAPSULE/detail_bead0.png")
@@ -415,7 +415,7 @@ class TimeCapsuleDetailServiceTest {
             }
         every { likeReader.getLikeCount(capsuleId) } returns 1
         every { timeCapsuleUserReader.getParticipantCount(capsuleId) } returns 2
-        every { timeCapsuleUserReader.getTimeCapsuleUserOrNull(capsuleId, userId) } returns timeCapsuleUser
+        every { timeCapsuleUserReader.findTimeCapsuleUser(capsuleId, userId) } returns timeCapsuleUser
         every { letterReader.getLetterCountByCapsuleId(capsuleId) } returns 3
         every {
             fileService.generatePresignedDownloadUrlByObjectKey("CAPSULE/detail_bead0.png")
@@ -458,7 +458,7 @@ class TimeCapsuleDetailServiceTest {
         every { likeReader.findByUserIdAndCapsuleId(any(), any()) } returns null
         every { likeReader.getLikeCount(capsuleId) } returns 0
         every { timeCapsuleUserReader.getParticipantCount(capsuleId) } returns 0
-        every { timeCapsuleUserReader.getTimeCapsuleUserOrNull(any(), any()) } returns null
+        every { timeCapsuleUserReader.findTimeCapsuleUser(any(), any()) } returns null
         every { letterReader.getLetterCountByCapsuleId(capsuleId) } returns 0
         every {
             fileService.generatePresignedDownloadUrlByObjectKey("CAPSULE/detail_bead0.png")


### PR DESCRIPTION
## 📌 Related Issue

> [!NOTE]
> 관련된 이슈 번호를 적어주세요.

- Close #108
- Close #107 

## 🚀 Description

> [!NOTE]
> 작업한 내용을 간략히 적어주세요.

```text
타임캡슐 나가기 로직 및 참여 로직 수정
```

## 📸 Screenshot
> [!NOTE]
> 변경 사항을 보여주는 스크린샷(또는 GIF)을 첨부해 주세요.

## 📢 Notes

> [!NOTE]
> 추가적인 설명이나 참고 사항을 작성해 주세요.

```text

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 타임캡슐 나가기(참여 탈퇴) API 추가.
  - 캡슐 상세 응답에 참여 여부(isJoined) 표시.

- **Bug Fixes**
  - 이미 탈퇴한 사용자는 해당 캡슐에 편지 작성 불가로 제한.
  - 참여하지 않음/이미 탈퇴 상태에 대한 오류 메시지 및 예외 처리 추가.

- **Refactor**
  - 참여자 집계·조회에서 활성 사용자만 집계하도록 변경.
  - 캡슐 생성 시 생성자 자동 참여 제거; 회원 상태 관리 도입.

- **Tests / DB**
  - 관련 단위테스트 추가/수정 및 회원 상태 컬럼 추가(DB 마이그레이션).

- **Documentation / Chores**
  - OpenAPI에 운영 서버 추가 및 프로덕션 컨테이너에 APM 볼륨 마운트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->