### PR TITLE
fix(#114): 전체 필터링에서 ACTIVE가 아닌 상태 수정

### DIFF
--- a/src/main/kotlin/com/yapp/lettie/domain/timecapsule/repository/TimeCapsuleCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/yapp/lettie/domain/timecapsule/repository/TimeCapsuleCustomRepositoryImpl.kt
@@ -126,7 +126,7 @@ class TimeCapsuleCustomRepositoryImpl(
         val participant = QTimeCapsuleUser.timeCapsuleUser
         val tcu = QTimeCapsuleUser("tcu")
 
-        val createdByMe = timeCapsule.creator.id.eq(userId)
+        val createdByMe = timeCapsule.creator.id.eq(userId).and(participant.status.eq(TimeCapsuleUserStatus.ACTIVE))
         val likedByMe = like.user.id.eq(userId).and(like.isLiked.isTrue)
         val participating =
             participant.user.id.eq(userId)

--- a/src/main/kotlin/com/yapp/lettie/domain/timecapsule/repository/TimeCapsuleCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/yapp/lettie/domain/timecapsule/repository/TimeCapsuleCustomRepositoryImpl.kt
@@ -126,28 +126,19 @@ class TimeCapsuleCustomRepositoryImpl(
         val participant = QTimeCapsuleUser.timeCapsuleUser
         val tcu = QTimeCapsuleUser("tcu")
 
+        val createdByMe = timeCapsule.creator.id.eq(userId)
+        val likedByMe = like.user.id.eq(userId).and(like.isLiked.isTrue)
+        val participating =
+            participant.user.id.eq(userId)
+                .and(participant.status.eq(TimeCapsuleUserStatus.ACTIVE))
+
         val builder =
             BooleanBuilder().apply {
                 when (filter) {
-                    MyCapsuleFilter.CREATED ->
-                        and(timeCapsule.creator.id.eq(userId))
-
-                    MyCapsuleFilter.LIKED ->
-                        and(like.user.id.eq(userId).and(like.isLiked.isTrue))
-
-                    MyCapsuleFilter.PARTICIPATING ->
-                        and(participant.user.id.eq(userId).and(participant.status.eq(TimeCapsuleUserStatus.ACTIVE)))
-
-                    MyCapsuleFilter.ALL ->
-                        and(
-                            timeCapsule.creator.id.eq(userId)
-                                .or(like.user.id.eq(userId).and(like.isLiked.isTrue))
-                                .or(
-                                    participant.user.id.eq(
-                                        userId,
-                                    ).and(participant.status.eq(TimeCapsuleUserStatus.ACTIVE)),
-                                ),
-                        )
+                    MyCapsuleFilter.CREATED -> and(createdByMe)
+                    MyCapsuleFilter.LIKED -> and(likedByMe)
+                    MyCapsuleFilter.PARTICIPATING -> and(participating)
+                    MyCapsuleFilter.ALL -> and(createdByMe.or(likedByMe).or(participating))
                 }
             }
 


### PR DESCRIPTION
## 📌 Related Issue

> [!NOTE]
> 관련된 이슈 번호를 적어주세요.

- Close #114

## 🚀 Description

> [!NOTE]
> 작업한 내용을 간략히 적어주세요.

```text

```

## 📸 Screenshot
> [!NOTE]
> 변경 사항을 보여주는 스크린샷(또는 GIF)을 첨부해 주세요.

## 📢 Notes

> [!NOTE]
> 추가적인 설명이나 참고 사항을 작성해 주세요.

```text

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * My 캡슐 필터 처리 로직을 정리해 중복을 제거하고 조건 조합을 중앙화했습니다.
  * CREATED 필터의 조건이 활성 참여자 맥락을 요구하도록 변경되어 일부 결과에 영향이 있을 수 있습니다.
  * LIKED/PARTICIPATING 필터와 ALL(세 조건의 OR 결합)은 명확히 정리되었습니다.
  * 공개 API 변경은 없으며 성능 영향은 없도록 유지했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->