### PR TITLE
fix(#121): 내가 만든 캡슐 필터링 조건식 변경

### DIFF
--- a/src/main/kotlin/com/yapp/lettie/domain/timecapsule/repository/TimeCapsuleCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/yapp/lettie/domain/timecapsule/repository/TimeCapsuleCustomRepositoryImpl.kt
@@ -130,7 +130,7 @@ class TimeCapsuleCustomRepositoryImpl(
             timeCapsule.creator.id.eq(userId)
                 .and(
                     participant.status.isNull
-                        .or(participant.status.ne(TimeCapsuleUserStatus.LEFT)),
+                        .or(participant.status.eq(TimeCapsuleUserStatus.ACTIVE)),
                 )
         val likedByMe = like.user.id.eq(userId).and(like.isLiked.isTrue)
         val participating =

--- a/src/main/kotlin/com/yapp/lettie/domain/timecapsule/repository/TimeCapsuleCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/yapp/lettie/domain/timecapsule/repository/TimeCapsuleCustomRepositoryImpl.kt
@@ -126,7 +126,12 @@ class TimeCapsuleCustomRepositoryImpl(
         val participant = QTimeCapsuleUser.timeCapsuleUser
         val tcu = QTimeCapsuleUser("tcu")
 
-        val createdByMe = timeCapsule.creator.id.eq(userId).and(participant.status.eq(TimeCapsuleUserStatus.ACTIVE))
+        val createdByMe =
+            timeCapsule.creator.id.eq(userId)
+                .and(
+                    participant.status.isNull
+                        .or(participant.status.ne(TimeCapsuleUserStatus.LEFT)),
+                )
         val likedByMe = like.user.id.eq(userId).and(like.isLiked.isTrue)
         val participating =
             participant.user.id.eq(userId)


### PR DESCRIPTION
## 📌 Related Issue

> [!NOTE]
> 관련된 이슈 번호를 적어주세요.

- Close #121

## 🚀 Description

> [!NOTE]
> 작업한 내용을 간략히 적어주세요.

```kotlin
val createdByMe = timeCapsule.creator.id.eq(userId)
                .and(
                    participant.status.isNull
                        .or(participant.status.ne(TimeCapsuleUserStatus.LEFT)),
                )
```

timeCapsuleUser가 편지에 참여할 때 만들어져서 isNull이거나 LEFT가 아닌 경우에 뜨도록 하였습니다
하지만 이렇게 됐을 경우 풀스캔을 돌 수 있고 인덱스도 타기 힘드므로...

```kotlin
val createdByMe =
            timeCapsule.creator.id.eq(userId)
                .and(
                    participant.status.isNull
                        .or(participant.status.eq(TimeCapsuleUserStatus.ACTIVE)),
                )
```
와 같이 수정!

## 📸 Screenshot
> [!NOTE]
> 변경 사항을 보여주는 스크린샷(또는 GIF)을 첨부해 주세요.

## 📢 Notes

> [!NOTE]
> 추가적인 설명이나 참고 사항을 작성해 주세요.

```text

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 버그 수정
  - 내 타임캡슐 목록에서 사용자가 만든 캡슐이 참여 정보가 없거나 활성 상태인 경우 누락되던 문제를 수정했습니다.
  - 이제 사용자는 자신이 만든 캡슐을 더 안정적이고 일관되게 확인할 수 있습니다.
  - 단, 참여 상태가 ‘나가기’인 경우는 기존과 동일하게 목록에서 제외됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->