### PR TITLE
feat(#127): private 전체 허용

### DIFF
--- a/src/main/kotlin/com/yapp/lettie/api/letter/service/LetterService.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/letter/service/LetterService.kt
@@ -82,7 +82,7 @@ class LetterService(
     ): LettersDto {
         val capsule = timeCapsuleReader.getById(payload.capsuleId)
 
-        validateTimeCapsuleRead(capsule.id, user.id)
+        validateTimeCapsuleRead(capsule.id)
 
         val letters = letterReader.findByCapsuleId(payload.capsuleId, payload.pageable)
         return LettersDto.of(user.id, letters)
@@ -94,23 +94,16 @@ class LetterService(
         letterId: Long,
     ): LetterDto {
         val letter = letterReader.getById(letterId)
-        validateTimeCapsuleRead(letter.timeCapsule.id, user.id)
+        validateTimeCapsuleRead(letter.timeCapsule.id)
 
         return LetterDto.of(user.id, letter)
     }
 
-    private fun validateTimeCapsuleRead(
-        capsuleId: Long,
-        userId: Long,
-    ) {
+    private fun validateTimeCapsuleRead(capsuleId: Long) {
         val capsule = timeCapsuleReader.getById(capsuleId)
 
         if (capsule.isNotOpen(LocalDateTime.now())) {
             throw ApiErrorException(ErrorMessages.NOT_OPENED_CAPSULE)
-        }
-
-        if (capsule.isPrivate() && capsule.timeCapsuleUsers.none { it.user.id == userId }) {
-            throw ApiErrorException(ErrorMessages.NOT_JOINED_TIME_CAPSULE)
         }
     }
 

--- a/src/test/kotlin/com/yapp/lettie/api/letter/service/LetterServiceTest.kt
+++ b/src/test/kotlin/com/yapp/lettie/api/letter/service/LetterServiceTest.kt
@@ -309,51 +309,6 @@ class LetterServiceTest {
     }
 
     @Test
-    fun `단일 편지 조회 시 프라이빗 타임캡슐에 참여하지 않은 사용자인 경우 예외를 발생시킨다`() {
-        // given
-        val userId = 1L
-        val letterId = 1L
-
-        val user =
-            UserInfoPayload(
-                id = userId,
-                roles = listOf(UserRole.USER.name),
-            )
-
-        val otherUser =
-            mockk<User> {
-                every { id } returns 2L
-            }
-
-        val timeCapsuleUser = mockk<TimeCapsuleUser>(relaxed = true)
-        every { timeCapsuleUser.user } returns otherUser
-
-        val capsule = mockk<TimeCapsule>()
-        every { capsule.id } returns 1L
-        every { capsule.isNotOpen(any()) } returns false
-        every { capsule.isPrivate() } returns true
-        every { capsule.timeCapsuleUsers } returns mutableListOf(timeCapsuleUser)
-
-        val mockLetter =
-            mockk<Letter> {
-                every { timeCapsule } returns capsule
-            }
-
-        every { letterReader.getById(letterId) } returns mockLetter
-        every { timeCapsuleReader.getById(1L) } returns capsule
-
-        // when & then
-        val exception =
-            assertThrows(ApiErrorException::class.java) {
-                letterService.readLetter(user, letterId)
-            }
-
-        assertEquals(ErrorMessages.NOT_JOINED_TIME_CAPSULE.message, exception.error.message)
-        verify(exactly = 1) { letterReader.getById(letterId) }
-        verify(exactly = 1) { timeCapsuleReader.getById(1L) }
-    }
-
-    @Test
     fun `단일 편지 조회 시 공개 타임캡슐은 참여하지 않아도 조회 가능하다`() {
         // given
         val userId = 1L
@@ -555,52 +510,6 @@ class LetterServiceTest {
             }
 
         assertEquals(ErrorMessages.NOT_OPENED_CAPSULE.message, exception.error.message)
-        verify(exactly = 2) { timeCapsuleReader.getById(capsuleId) }
-        verify(exactly = 0) { letterReader.findByCapsuleId(any(), any()) }
-    }
-
-    @Test
-    fun `편지 목록 조회 시 프라이빗 타임캡슐에 참여하지 않은 사용자인 경우 예외를 발생시킨다`() {
-        // given
-        val userId = 1L
-        val capsuleId = 1L
-        val pageable = PageRequest.of(0, 20)
-
-        val user =
-            UserInfoPayload(
-                id = userId,
-                roles = listOf(UserRole.USER.name),
-            )
-
-        val payload =
-            GetLettersPayload(
-                capsuleId = capsuleId,
-                pageable = pageable,
-            )
-
-        val otherUser =
-            mockk<User> {
-                every { id } returns 2L
-            }
-
-        val timeCapsuleUser = mockk<TimeCapsuleUser>(relaxed = true)
-        every { timeCapsuleUser.user } returns otherUser
-
-        val capsule = mockk<TimeCapsule>()
-        every { capsule.id } returns capsuleId
-        every { capsule.isNotOpen(any()) } returns false
-        every { capsule.isPrivate() } returns true
-        every { capsule.timeCapsuleUsers } returns mutableListOf(timeCapsuleUser)
-
-        every { timeCapsuleReader.getById(capsuleId) } returns capsule
-
-        // when & then
-        val exception =
-            assertThrows(ApiErrorException::class.java) {
-                letterService.readLetters(user, payload)
-            }
-
-        assertEquals(ErrorMessages.NOT_JOINED_TIME_CAPSULE.message, exception.error.message)
         verify(exactly = 2) { timeCapsuleReader.getById(capsuleId) }
         verify(exactly = 0) { letterReader.findByCapsuleId(any(), any()) }
     }


### PR DESCRIPTION
## 📌 Related Issue

> [!NOTE]
> 관련된 이슈 번호를 적어주세요.

- Close #127 

## 🚀 Description

> [!NOTE]
> 작업한 내용을 간략히 적어주세요.

```text
private 전체 허용

```

## 📸 Screenshot
> [!NOTE]
> 변경 사항을 보여주는 스크린샷(또는 GIF)을 첨부해 주세요.

## 📢 Notes

> [!NOTE]
> 추가적인 설명이나 참고 사항을 작성해 주세요.

```text

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 비공개 타임캡슐이 공개된 이후에는 참여하지 않은 사용자도 편지 목록 및 상세를 조회할 수 있도록 접근 제한을 완화했습니다.

* 테스트
  * 비공개 타임캡슐 미참여자의 조회 오류 관련 테스트를 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->