### PR TITLE
refactor(#123): 타임캡슐 오픈시 첫 오픈 여부 반환 로직 수정

### DIFF
--- a/src/main/kotlin/com/yapp/lettie/api/ApiPath.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/ApiPath.kt
@@ -25,7 +25,9 @@ enum class ApiPath(
     TIME_CAPSULE_JOIN("/api/v1/capsules/{capsuleId}/join", HttpMethod.POST, AuthType.REQUIRED),
     TIME_CAPSULE_LEAVE("/api/v1/capsules/{capsuleId}/leave", HttpMethod.DELETE, AuthType.REQUIRED),
     TIME_CAPSULE_LIKE("/api/v1/capsules/{capsuleId}/like", HttpMethod.POST, AuthType.REQUIRED),
+    TiME_CAPSULE_UNLIKE("/api/v1/capsules/{capsuleId}/like", HttpMethod.DELETE, AuthType.REQUIRED),
     TIME_CAPSULE_DETAIL("/api/v1/capsules/{capsuleId}", HttpMethod.GET, AuthType.OPTIONAL),
+    Time_CAPSULE_OPEN("/api/v1/capsules/{capsuleId}/open", HttpMethod.POST, AuthType.OPTIONAL),
 
     // 메인페이지 조회 API
     TIME_CAPSULE_MAIN_MY_LIST("/api/v1/capsules/my", HttpMethod.GET, AuthType.REQUIRED),

--- a/src/main/kotlin/com/yapp/lettie/api/ApiPath.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/ApiPath.kt
@@ -25,9 +25,9 @@ enum class ApiPath(
     TIME_CAPSULE_JOIN("/api/v1/capsules/{capsuleId}/join", HttpMethod.POST, AuthType.REQUIRED),
     TIME_CAPSULE_LEAVE("/api/v1/capsules/{capsuleId}/leave", HttpMethod.DELETE, AuthType.REQUIRED),
     TIME_CAPSULE_LIKE("/api/v1/capsules/{capsuleId}/like", HttpMethod.POST, AuthType.REQUIRED),
-    TiME_CAPSULE_UNLIKE("/api/v1/capsules/{capsuleId}/like", HttpMethod.DELETE, AuthType.REQUIRED),
+    TIME_CAPSULE_UNLIKE("/api/v1/capsules/{capsuleId}/like", HttpMethod.DELETE, AuthType.REQUIRED),
     TIME_CAPSULE_DETAIL("/api/v1/capsules/{capsuleId}", HttpMethod.GET, AuthType.OPTIONAL),
-    Time_CAPSULE_OPEN("/api/v1/capsules/{capsuleId}/open", HttpMethod.POST, AuthType.OPTIONAL),
+    TIME_CAPSULE_OPEN("/api/v1/capsules/{capsuleId}/open", HttpMethod.POST, AuthType.OPTIONAL),
 
     // 메인페이지 조회 API
     TIME_CAPSULE_MAIN_MY_LIST("/api/v1/capsules/my", HttpMethod.GET, AuthType.REQUIRED),

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/TimeCapsuleApiController.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/TimeCapsuleApiController.kt
@@ -67,10 +67,9 @@ class TimeCapsuleApiController(
     ): ResponseEntity<ApiResponse<OpenTimeCapsuleResponse>> =
         ResponseEntity.ok(
             ApiResponse.success(
-                OpenTimeCapsuleResponse.from(timeCapsuleService.openTimeCapsule(capsuleId, userInfo?.id))
-                )
+                OpenTimeCapsuleResponse.from(timeCapsuleService.openTimeCapsule(capsuleId, userInfo?.id)),
+            ),
         )
-
 
     @Deprecated("편지 작성 시 자동 참여 처리로 인해 더 이상 사용되지 않습니다. 추후 제거 예정입니다.")
     @PostMapping("/{capsuleId}/join")

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/TimeCapsuleApiController.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/TimeCapsuleApiController.kt
@@ -3,6 +3,7 @@ package com.yapp.lettie.api.timecapsule.controller
 import com.yapp.lettie.api.auth.annotation.LoginUser
 import com.yapp.lettie.api.timecapsule.controller.request.CreateTimeCapsuleRequest
 import com.yapp.lettie.api.timecapsule.controller.response.CreateTimeCapsuleResponse
+import com.yapp.lettie.api.timecapsule.controller.response.OpenTimeCapsuleResponse
 import com.yapp.lettie.api.timecapsule.controller.swagger.TimeCapsuleSwagger
 import com.yapp.lettie.api.timecapsule.service.TimeCapsuleService
 import com.yapp.lettie.common.dto.ApiResponse
@@ -58,6 +59,18 @@ class TimeCapsuleApiController(
         timeCapsuleService.leaveTimeCapsule(userInfo.id, capsuleId)
         return ResponseEntity.ok(ApiResponse.success(true))
     }
+
+    @PostMapping("/{capsuleId}/open")
+    override fun open(
+        @LoginUser userInfo: UserInfoPayload?,
+        @PathVariable capsuleId: Long,
+    ): ResponseEntity<ApiResponse<OpenTimeCapsuleResponse>> =
+        ResponseEntity.ok(
+            ApiResponse.success(
+                OpenTimeCapsuleResponse.from(timeCapsuleService.openTimeCapsule(capsuleId, userInfo?.id))
+                )
+        )
+
 
     @Deprecated("편지 작성 시 자동 참여 처리로 인해 더 이상 사용되지 않습니다. 추후 제거 예정입니다.")
     @PostMapping("/{capsuleId}/join")

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/response/OpenTimeCapsuleResponse.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/response/OpenTimeCapsuleResponse.kt
@@ -1,0 +1,14 @@
+package com.yapp.lettie.api.timecapsule.controller.response
+
+import com.yapp.lettie.api.timecapsule.service.dto.OpenTimeCapsuleDto
+
+data class OpenTimeCapsuleResponse(
+    val isFirstOpen: Boolean,
+) {
+    companion object {
+        fun from(dto: OpenTimeCapsuleDto): OpenTimeCapsuleResponse =
+            OpenTimeCapsuleResponse(
+                isFirstOpen = dto.isFirstOpen,
+            )
+    }
+}

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/swagger/TimeCapsuleSwagger.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/swagger/TimeCapsuleSwagger.kt
@@ -60,7 +60,7 @@ interface TimeCapsuleSwagger {
 
     @Operation(
         summary = "타임캡슐 열기",
-        description = "캡슐을 열고 '처음 오픈 여부'를 반환합니다. 만약 처음 오픈하는 것이라면 false로 업데이트합니다."
+        description = "캡슐을 열고 '처음 오픈 여부'를 반환합니다. 만약 처음 오픈하는 것이라면 false로 업데이트합니다.",
     )
     fun open(
         userInfo: UserInfoPayload?,

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/swagger/TimeCapsuleSwagger.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/swagger/TimeCapsuleSwagger.kt
@@ -2,6 +2,7 @@ package com.yapp.lettie.api.timecapsule.controller.swagger
 
 import com.yapp.lettie.api.timecapsule.controller.request.CreateTimeCapsuleRequest
 import com.yapp.lettie.api.timecapsule.controller.response.CreateTimeCapsuleResponse
+import com.yapp.lettie.api.timecapsule.controller.response.OpenTimeCapsuleResponse
 import com.yapp.lettie.common.dto.ApiResponse
 import com.yapp.lettie.common.dto.UserInfoPayload
 import io.swagger.v3.oas.annotations.Operation
@@ -56,4 +57,13 @@ interface TimeCapsuleSwagger {
         userInfo: UserInfoPayload,
         capsuleId: Long,
     ): ResponseEntity<ApiResponse<Boolean>>
+
+    @Operation(
+        summary = "타임캡슐 열기",
+        description = "캡슐을 열고 '처음 오픈 여부'를 반환합니다. 만약 처음 오픈하는 것이라면 false로 업데이트합니다."
+    )
+    fun open(
+        userInfo: UserInfoPayload?,
+        capsuleId: Long,
+    ): ResponseEntity<ApiResponse<OpenTimeCapsuleResponse>>
 }

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/swagger/TimeCapsuleSwagger.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/controller/swagger/TimeCapsuleSwagger.kt
@@ -60,7 +60,7 @@ interface TimeCapsuleSwagger {
 
     @Operation(
         summary = "타임캡슐 열기",
-        description = "캡슐을 열고 '처음 오픈 여부'를 반환합니다. 만약 처음 오픈하는 것이라면 false로 업데이트합니다.",
+        description = "캡슐을 열고 '처음 오픈 여부'를 반환합니다. 만약 처음 오픈하는 것이라면 true를 반환하고 false로 업데이트합니다.",
     )
     fun open(
         userInfo: UserInfoPayload?,

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailService.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailService.kt
@@ -47,9 +47,12 @@ class TimeCapsuleDetailService(
         val (isFirstOpen, isMine, isJoined) =
             if (userId != null) {
                 val timeCapsuleUser = timeCapsuleUserReader.findTimeCapsuleUser(capsuleId, userId)
-                val firstOpen = timeCapsuleUser?.let { !it.isOpened } ?: false
+                val isFirstOpen =
+                    timeCapsuleUser?.let { user ->
+                        user.isOpened == false
+                    } ?: false
                 val joined = timeCapsuleUser?.isActive ?: false
-                Triple(firstOpen, capsule.creator.id == userId, joined)
+                Triple(isFirstOpen, capsule.creator.id == userId, joined)
             } else {
                 Triple(false, false, false)
             }

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailService.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailService.kt
@@ -11,7 +11,6 @@ import com.yapp.lettie.api.timecapsule.service.dto.TimeCapsuleSummariesDto
 import com.yapp.lettie.api.timecapsule.service.reader.TimeCapsuleLikeReader
 import com.yapp.lettie.api.timecapsule.service.reader.TimeCapsuleReader
 import com.yapp.lettie.api.timecapsule.service.reader.TimeCapsuleUserReader
-import com.yapp.lettie.api.timecapsule.service.writer.TimeCapsuleUserWriter
 import com.yapp.lettie.domain.timecapsule.entity.TimeCapsule
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -24,7 +23,6 @@ class TimeCapsuleDetailService(
     private val timeCapsuleReader: TimeCapsuleReader,
     private val timeCapsuleLikeReader: TimeCapsuleLikeReader,
     private val timeCapsuleUserReader: TimeCapsuleUserReader,
-    private val timeCapsuleUserWriter: TimeCapsuleUserWriter,
     private val letterReader: LetterReader,
 ) {
     fun getTimeCapsuleDetail(

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailService.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailService.kt
@@ -45,10 +45,11 @@ class TimeCapsuleDetailService(
         val (isFirstOpen, isMine, isJoined) =
             if (userId != null) {
                 val timeCapsuleUser = timeCapsuleUserReader.findTimeCapsuleUser(capsuleId, userId)
-                val isFirstOpen =
-                    timeCapsuleUser?.let { user ->
-                        user.isOpened == false
-                    } ?: false
+                val isFirstOpen = timeCapsuleUser
+                    ?.takeIf { it.isActive }
+                    ?.let { !it.isOpened }
+                    ?: false
+
                 val joined = timeCapsuleUser?.isActive ?: false
                 Triple(isFirstOpen, capsule.creator.id == userId, joined)
             } else {

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailService.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailService.kt
@@ -48,10 +48,6 @@ class TimeCapsuleDetailService(
             if (userId != null) {
                 val timeCapsuleUser = timeCapsuleUserReader.findTimeCapsuleUser(capsuleId, userId)
                 val firstOpen = timeCapsuleUser?.let { !it.isOpened } ?: false
-                if (firstOpen && timeCapsuleUser != null) {
-                    timeCapsuleUser.updateOpened()
-                    timeCapsuleUserWriter.save(timeCapsuleUser)
-                }
                 val joined = timeCapsuleUser?.isActive ?: false
                 Triple(firstOpen, capsule.creator.id == userId, joined)
             } else {

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailService.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailService.kt
@@ -45,10 +45,11 @@ class TimeCapsuleDetailService(
         val (isFirstOpen, isMine, isJoined) =
             if (userId != null) {
                 val timeCapsuleUser = timeCapsuleUserReader.findTimeCapsuleUser(capsuleId, userId)
-                val isFirstOpen = timeCapsuleUser
-                    ?.takeIf { it.isActive }
-                    ?.let { !it.isOpened }
-                    ?: false
+                val isFirstOpen =
+                    timeCapsuleUser
+                        ?.takeIf { it.isActive }
+                        ?.let { !it.isOpened }
+                        ?: false
 
                 val joined = timeCapsuleUser?.isActive ?: false
                 Triple(isFirstOpen, capsule.creator.id == userId, joined)

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleService.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleService.kt
@@ -2,9 +2,12 @@ package com.yapp.lettie.api.timecapsule.service
 
 import com.yapp.lettie.api.timecapsule.service.dto.CreateTimeCapsuleDto
 import com.yapp.lettie.api.timecapsule.service.dto.CreateTimeCapsulePayload
+import com.yapp.lettie.api.timecapsule.service.dto.OpenTimeCapsuleDto
 import com.yapp.lettie.api.timecapsule.service.reader.TimeCapsuleLikeReader
 import com.yapp.lettie.api.timecapsule.service.reader.TimeCapsuleReader
+import com.yapp.lettie.api.timecapsule.service.reader.TimeCapsuleUserReader
 import com.yapp.lettie.api.timecapsule.service.writer.TimeCapsuleLikeWriter
+import com.yapp.lettie.api.timecapsule.service.writer.TimeCapsuleUserWriter
 import com.yapp.lettie.api.timecapsule.service.writer.TimeCapsuleWriter
 import com.yapp.lettie.api.user.service.reader.UserReader
 import com.yapp.lettie.common.error.ErrorMessages
@@ -24,6 +27,8 @@ class TimeCapsuleService(
     private val timeCapsuleReader: TimeCapsuleReader,
     private val timeCapsuleLikeWriter: TimeCapsuleLikeWriter,
     private val timeCapsuleLikeReader: TimeCapsuleLikeReader,
+    private val timeCapsuleUserReader: TimeCapsuleUserReader,
+    private val timeCapsuleUserWriter: TimeCapsuleUserWriter,
 ) {
     @Transactional
     fun createTimeCapsule(
@@ -113,6 +118,23 @@ class TimeCapsuleService(
                 ?: throw ApiErrorException(ErrorMessages.NOT_JOINED_CAPSULE)
 
         timeCapsuleUser.leave()
+    }
+
+    @Transactional
+    fun openTimeCapsule(capsuleId: Long, userId: Long?): OpenTimeCapsuleDto {
+        if (userId == null) {
+            return OpenTimeCapsuleDto(isFirstOpen = false)
+        }
+
+        val timeCapsuleUser = timeCapsuleUserReader.findTimeCapsuleUser(capsuleId, userId)
+            ?: return OpenTimeCapsuleDto(isFirstOpen = false)
+
+        val isFirstOpen = timeCapsuleUser.isOpened
+        if (!isFirstOpen) {
+            timeCapsuleUser.updateOpened()
+        }
+
+        return OpenTimeCapsuleDto(isFirstOpen = isFirstOpen)
     }
 
     private fun generateInviteCode(): String = UUID.randomUUID().toString().take(RANDOM_VALUE_LENGTH)

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleService.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleService.kt
@@ -121,13 +121,17 @@ class TimeCapsuleService(
     }
 
     @Transactional
-    fun openTimeCapsule(capsuleId: Long, userId: Long?): OpenTimeCapsuleDto {
+    fun openTimeCapsule(
+        capsuleId: Long,
+        userId: Long?,
+    ): OpenTimeCapsuleDto {
         if (userId == null) {
             return OpenTimeCapsuleDto(isFirstOpen = false)
         }
 
-        val timeCapsuleUser = timeCapsuleUserReader.findTimeCapsuleUser(capsuleId, userId)
-            ?: return OpenTimeCapsuleDto(isFirstOpen = false)
+        val timeCapsuleUser =
+            timeCapsuleUserReader.findTimeCapsuleUser(capsuleId, userId)
+                ?: return OpenTimeCapsuleDto(isFirstOpen = false)
 
         val isFirstOpen = timeCapsuleUser.isOpened
         if (!isFirstOpen) {

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleService.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleService.kt
@@ -7,7 +7,6 @@ import com.yapp.lettie.api.timecapsule.service.reader.TimeCapsuleLikeReader
 import com.yapp.lettie.api.timecapsule.service.reader.TimeCapsuleReader
 import com.yapp.lettie.api.timecapsule.service.reader.TimeCapsuleUserReader
 import com.yapp.lettie.api.timecapsule.service.writer.TimeCapsuleLikeWriter
-import com.yapp.lettie.api.timecapsule.service.writer.TimeCapsuleUserWriter
 import com.yapp.lettie.api.timecapsule.service.writer.TimeCapsuleWriter
 import com.yapp.lettie.api.user.service.reader.UserReader
 import com.yapp.lettie.common.error.ErrorMessages
@@ -28,7 +27,6 @@ class TimeCapsuleService(
     private val timeCapsuleLikeWriter: TimeCapsuleLikeWriter,
     private val timeCapsuleLikeReader: TimeCapsuleLikeReader,
     private val timeCapsuleUserReader: TimeCapsuleUserReader,
-    private val timeCapsuleUserWriter: TimeCapsuleUserWriter,
 ) {
     @Transactional
     fun createTimeCapsule(

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleService.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleService.kt
@@ -55,6 +55,7 @@ class TimeCapsuleService(
     }
 
     @Transactional
+    @Deprecated("Use joinTimeCapsule instead")
     fun joinTimeCapsule(
         userId: Long,
         capsuleId: Long,
@@ -125,20 +126,18 @@ class TimeCapsuleService(
         capsuleId: Long,
         userId: Long?,
     ): OpenTimeCapsuleDto {
-        if (userId == null) {
-            return OpenTimeCapsuleDto(isFirstOpen = false)
-        }
-
         val timeCapsuleUser =
-            timeCapsuleUserReader.findTimeCapsuleUser(capsuleId, userId)
-                ?: return OpenTimeCapsuleDto(isFirstOpen = false)
+            userId?.let {
+                timeCapsuleUserReader.findTimeCapsuleUser(capsuleId, it)
+            } ?: return OpenTimeCapsuleDto(isFirstOpen = false)
 
-        val isFirstOpen = timeCapsuleUser.isOpened
-        if (!isFirstOpen) {
-            timeCapsuleUser.updateOpened()
+        return when (timeCapsuleUser.isOpened) {
+            true -> OpenTimeCapsuleDto(isFirstOpen = false)
+            false -> {
+                timeCapsuleUser.updateOpened()
+                OpenTimeCapsuleDto(isFirstOpen = true)
+            }
         }
-
-        return OpenTimeCapsuleDto(isFirstOpen = isFirstOpen)
     }
 
     private fun generateInviteCode(): String = UUID.randomUUID().toString().take(RANDOM_VALUE_LENGTH)

--- a/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/dto/OpenTimeCapsuleDto.kt
+++ b/src/main/kotlin/com/yapp/lettie/api/timecapsule/service/dto/OpenTimeCapsuleDto.kt
@@ -1,0 +1,5 @@
+package com.yapp.lettie.api.timecapsule.service.dto
+
+data class OpenTimeCapsuleDto(
+    val isFirstOpen: Boolean,
+)

--- a/src/main/kotlin/com/yapp/lettie/domain/timecapsule/entity/TimeCapsuleUser.kt
+++ b/src/main/kotlin/com/yapp/lettie/domain/timecapsule/entity/TimeCapsuleUser.kt
@@ -33,16 +33,18 @@ class TimeCapsuleUser(
     var isOpened: Boolean = false,
     @Column(name = "status", nullable = false)
     @Enumerated(EnumType.STRING)
-    var status: TimeCapsuleUserStatus = TimeCapsuleUserStatus.ACTIVE,
+    var status: TimeCapsuleUserStatus,
 ) : BaseEntity() {
     companion object {
         fun of(
             user: User,
             timeCapsule: TimeCapsule,
+            status: TimeCapsuleUserStatus = TimeCapsuleUserStatus.NEVER_JOINED,
         ): TimeCapsuleUser =
             TimeCapsuleUser(
                 user = user,
                 timeCapsule = timeCapsule,
+                status = status,
             )
     }
 

--- a/src/main/kotlin/com/yapp/lettie/domain/timecapsule/entity/TimeCapsuleUser.kt
+++ b/src/main/kotlin/com/yapp/lettie/domain/timecapsule/entity/TimeCapsuleUser.kt
@@ -33,18 +33,16 @@ class TimeCapsuleUser(
     var isOpened: Boolean = false,
     @Column(name = "status", nullable = false)
     @Enumerated(EnumType.STRING)
-    var status: TimeCapsuleUserStatus,
+    var status: TimeCapsuleUserStatus = TimeCapsuleUserStatus.ACTIVE,
 ) : BaseEntity() {
     companion object {
         fun of(
             user: User,
             timeCapsule: TimeCapsule,
-            status: TimeCapsuleUserStatus = TimeCapsuleUserStatus.NEVER_JOINED,
         ): TimeCapsuleUser =
             TimeCapsuleUser(
                 user = user,
                 timeCapsule = timeCapsule,
-                status = status,
             )
     }
 

--- a/src/test/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailServiceTest.kt
+++ b/src/test/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleDetailServiceTest.kt
@@ -139,10 +139,6 @@ class TimeCapsuleDetailServiceTest {
         assertNotNull(result.remainingTime)
         assertEquals(1, result.remainingTime?.days)
         assertEquals("https://mocked-url.com/CAPSULE/detail_bead0.png", result.beadVideoUrl)
-
-        // 첫 방문이므로 updateOpened()와 save()가 호출되었는지 확인
-        verify { timeCapsuleUser.updateOpened() }
-        verify { timeCapsuleUserWriter.save(timeCapsuleUser) }
     }
 
     @Test

--- a/src/test/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleServiceTest.kt
+++ b/src/test/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleServiceTest.kt
@@ -13,7 +13,6 @@ import com.yapp.lettie.domain.timecapsule.entity.TimeCapsule
 import com.yapp.lettie.domain.timecapsule.entity.TimeCapsuleLike
 import com.yapp.lettie.domain.timecapsule.entity.TimeCapsuleUser
 import com.yapp.lettie.domain.timecapsule.entity.vo.AccessType
-import com.yapp.lettie.domain.timecapsule.entity.vo.TimeCapsuleUserStatus
 import com.yapp.lettie.domain.user.entity.User
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
@@ -206,20 +205,23 @@ class TimeCapsuleServiceTest {
         // given
         val userId = 1L
         val user = mockk<User>(relaxed = true)
-        val payload = CreateTimeCapsulePayload(
-            title = "title",
-            subtitle = "sub",
-            accessType = AccessType.PRIVATE,
-            openAt = LocalDateTime.now().minusDays(1), // 과거 시간
-            closedAt = LocalDateTime.now(),
-        )
+        // openAt을 과거 시간으로 설정
+        val payload =
+            CreateTimeCapsulePayload(
+                title = "title",
+                subtitle = "sub",
+                accessType = AccessType.PRIVATE,
+                openAt = LocalDateTime.now().minusDays(1),
+                closedAt = LocalDateTime.now(),
+            )
 
         every { userReader.getById(userId) } returns user
 
         // when & then
-        val exception = assertThrows<ApiErrorException> {
-            timeCapsuleService.createTimeCapsule(userId, payload)
-        }
+        val exception =
+            assertThrows<ApiErrorException> {
+                timeCapsuleService.createTimeCapsule(userId, payload)
+            }
 
         assertThat(exception.error.message).isEqualTo(ErrorMessages.INVALID_OPEN_AT.message)
     }
@@ -229,20 +231,23 @@ class TimeCapsuleServiceTest {
         // given
         val userId = 1L
         val user = mockk<User>(relaxed = true)
-        val payload = CreateTimeCapsulePayload(
-            title = "title",
-            subtitle = "sub",
-            accessType = AccessType.PRIVATE,
-            openAt = LocalDateTime.now().plusDays(5),
-            closedAt = LocalDateTime.now().plusDays(10), // openAt보다 늦음
-        )
+        // closedAt을 openAt보다 늦은 시간으로 설정
+        val payload =
+            CreateTimeCapsulePayload(
+                title = "title",
+                subtitle = "sub",
+                accessType = AccessType.PRIVATE,
+                openAt = LocalDateTime.now().plusDays(5),
+                closedAt = LocalDateTime.now().plusDays(10),
+            )
 
         every { userReader.getById(userId) } returns user
 
         // when & then
-        val exception = assertThrows<ApiErrorException> {
-            timeCapsuleService.createTimeCapsule(userId, payload)
-        }
+        val exception =
+            assertThrows<ApiErrorException> {
+                timeCapsuleService.createTimeCapsule(userId, payload)
+            }
 
         assertThat(exception.error.message).isEqualTo(ErrorMessages.INVALID_CLOSED_AT.message)
     }
@@ -254,9 +259,10 @@ class TimeCapsuleServiceTest {
         val capsuleId = 10L
         val user = mockk<User> { every { id } returns userId }
         val timeCapsuleUser = spyk(TimeCapsuleUser.of(user, mockk(relaxed = true)))
-        val capsule = mockk<TimeCapsule> {
-            every { timeCapsuleUsers } returns mutableListOf(timeCapsuleUser)
-        }
+        val capsule =
+            mockk<TimeCapsule> {
+                every { timeCapsuleUsers } returns mutableListOf(timeCapsuleUser)
+            }
 
         every { capsuleReader.getById(capsuleId) } returns capsule
 
@@ -272,16 +278,18 @@ class TimeCapsuleServiceTest {
         // given
         val userId = 1L
         val capsuleId = 10L
-        val capsule = mockk<TimeCapsule> {
-            every { timeCapsuleUsers } returns mutableListOf()
-        }
+        val capsule =
+            mockk<TimeCapsule> {
+                every { timeCapsuleUsers } returns mutableListOf()
+            }
 
         every { capsuleReader.getById(capsuleId) } returns capsule
 
         // when & then
-        val exception = assertThrows<ApiErrorException> {
-            timeCapsuleService.leaveTimeCapsule(userId, capsuleId)
-        }
+        val exception =
+            assertThrows<ApiErrorException> {
+                timeCapsuleService.leaveTimeCapsule(userId, capsuleId)
+            }
 
         assertThat(exception.error.message).isEqualTo(ErrorMessages.NOT_JOINED_CAPSULE.message)
     }
@@ -294,16 +302,18 @@ class TimeCapsuleServiceTest {
         val user = mockk<User> { every { id } returns userId }
         val timeCapsuleUser = spyk(TimeCapsuleUser.of(user, mockk(relaxed = true)))
         timeCapsuleUser.leave() // 이미 떠난 상태
-        val capsule = mockk<TimeCapsule> {
-            every { timeCapsuleUsers } returns mutableListOf(timeCapsuleUser)
-        }
+        val capsule =
+            mockk<TimeCapsule> {
+                every { timeCapsuleUsers } returns mutableListOf(timeCapsuleUser)
+            }
 
         every { capsuleReader.getById(capsuleId) } returns capsule
 
         // when & then
-        val exception = assertThrows<ApiErrorException> {
-            timeCapsuleService.leaveTimeCapsule(userId, capsuleId)
-        }
+        val exception =
+            assertThrows<ApiErrorException> {
+                timeCapsuleService.leaveTimeCapsule(userId, capsuleId)
+            }
 
         assertThat(exception.error.message).isEqualTo(ErrorMessages.NOT_JOINED_CAPSULE.message)
     }

--- a/src/test/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleServiceTest.kt
+++ b/src/test/kotlin/com/yapp/lettie/api/timecapsule/service/TimeCapsuleServiceTest.kt
@@ -3,6 +3,7 @@ package com.yapp.lettie.api.timecapsule.service
 import com.yapp.lettie.api.timecapsule.service.dto.CreateTimeCapsulePayload
 import com.yapp.lettie.api.timecapsule.service.reader.TimeCapsuleLikeReader
 import com.yapp.lettie.api.timecapsule.service.reader.TimeCapsuleReader
+import com.yapp.lettie.api.timecapsule.service.reader.TimeCapsuleUserReader
 import com.yapp.lettie.api.timecapsule.service.writer.TimeCapsuleLikeWriter
 import com.yapp.lettie.api.timecapsule.service.writer.TimeCapsuleWriter
 import com.yapp.lettie.api.user.service.reader.UserReader
@@ -40,6 +41,8 @@ class TimeCapsuleServiceTest {
 
     @MockK lateinit var capsuleLikeReader: TimeCapsuleLikeReader
 
+    @MockK lateinit var capsuleUserReader: TimeCapsuleUserReader
+
     @InjectMockKs
     lateinit var timeCapsuleService: TimeCapsuleService
 
@@ -73,79 +76,6 @@ class TimeCapsuleServiceTest {
         verify { capsuleWriter.save(any()) }
         assertThat(result.id).isEqualTo(123L)
         assertThat(result.inviteCode).isEqualTo("abcd1234")
-    }
-
-    @Test
-    fun `타임캡슐에 처음 참여하는 유저는 정상적으로 참여된다`() {
-        // given
-        val userId = 1L
-        val capsuleId = 99L
-        val user = mockk<User>(relaxed = true) { every { id } returns userId }
-        val capsule =
-            mockk<TimeCapsule>(relaxed = true) {
-                every { timeCapsuleUsers } returns mutableListOf()
-                every { closedAt } returns LocalDateTime.now().plusDays(1)
-            }
-
-        every { userReader.getById(userId) } returns user
-        every { capsuleReader.getById(capsuleId) } returns capsule
-
-        // when
-        timeCapsuleService.joinTimeCapsule(userId, capsuleId)
-
-        // then
-        verify { capsule.addUser(any()) }
-        verify { user.addTimeCapsuleUser(any()) }
-    }
-
-    @Test
-    fun `이미 참여한 유저가 다시 참여하면 예외가 발생한다`() {
-        // given
-        val userId = 1L
-        val capsuleId = 99L
-        val user = mockk<User> { every { id } returns userId }
-        val capsule = mockk<TimeCapsule>(relaxed = true)
-
-        val existing = TimeCapsuleUser.of(user, capsule)
-
-        every { userReader.getById(userId) } returns user
-        every { capsuleReader.getById(capsuleId) } returns capsule
-        every { capsule.timeCapsuleUsers } returns mutableListOf(existing)
-        every { capsule.closedAt } returns LocalDateTime.now().plusDays(1)
-
-        // when
-        val exception =
-            assertThrows<ApiErrorException> {
-                timeCapsuleService.joinTimeCapsule(userId, capsuleId)
-            }
-
-        // then
-        assertThat(exception.error.message).isEqualTo(ErrorMessages.ALREADY_JOINED.message)
-    }
-
-    @Test
-    fun `closedAt을 지난 타임캡슐에 참여하면 예외가 발생한다`() {
-        // given
-        val userId = 1L
-        val capsuleId = 100L
-        val user = mockk<User> { every { id } returns userId }
-        val capsule =
-            mockk<TimeCapsule> {
-                every { timeCapsuleUsers } returns mutableListOf()
-                every { isClosed(any()) } returns true
-            }
-
-        every { userReader.getById(userId) } returns user
-        every { capsuleReader.getById(capsuleId) } returns capsule
-
-        // when & then
-        val exception =
-            assertThrows<ApiErrorException> {
-                timeCapsuleService.joinTimeCapsule(userId, capsuleId)
-            }
-
-        // then
-        assertThat(exception.error.message).isEqualTo(ErrorMessages.CLOSED_TIME_CAPSULE.message)
     }
 
     @Test
@@ -196,10 +126,10 @@ class TimeCapsuleServiceTest {
     }
 
     @Test
-    fun `좋아요가 이미 되어 있는 상태에서 unlike를 하면 false로 변경된다`() {
+    fun `이미 좋아요한 상태에서 좋아요를 누르면 저장되지 않는다`() {
         // given
         val userId = 1L
-        val capsuleId = 30L
+        val capsuleId = 20L
         val user = mockk<User>()
         val capsule = mockk<TimeCapsule>()
         val existingLike = spyk(TimeCapsuleLike.of(user, capsule))
@@ -207,6 +137,25 @@ class TimeCapsuleServiceTest {
 
         every { userReader.getById(userId) } returns user
         every { capsuleReader.getById(capsuleId) } returns capsule
+        every { capsuleLikeReader.findByUserIdAndCapsuleId(userId, capsuleId) } returns existingLike
+
+        // when
+        timeCapsuleService.like(userId, capsuleId)
+
+        // then
+        verify(exactly = 0) { capsuleLikeWriter.save(any()) }
+    }
+
+    @Test
+    fun `좋아요 취소시 기존 좋아요가 있으면 false로 변경된다`() {
+        // given
+        val userId = 1L
+        val capsuleId = 20L
+        val user = mockk<User>()
+        val capsule = mockk<TimeCapsule>()
+        val existingLike = spyk(TimeCapsuleLike.of(user, capsule))
+        existingLike.isLiked = true
+
         every { capsuleLikeReader.findByUserIdAndCapsuleId(userId, capsuleId) } returns existingLike
         every { capsuleLikeWriter.save(existingLike) } returns existingLike
 
@@ -219,117 +168,207 @@ class TimeCapsuleServiceTest {
     }
 
     @Test
-    fun `활성 상태인 사용자가 캡슐을 나가면 상태가 LEFT로 변경된다`() {
+    fun `좋아요 취소시 기존 좋아요가 없으면 아무것도 하지 않는다`() {
         // given
         val userId = 1L
-        val capsuleId = 40L
-        val user = mockk<User> { every { id } returns userId }
-        val capsule = mockk<TimeCapsule>(relaxed = true)
-        val timeCapsuleUser = spyk(TimeCapsuleUser.of(user, capsule))
+        val capsuleId = 20L
+
+        every { capsuleLikeReader.findByUserIdAndCapsuleId(userId, capsuleId) } returns null
+
+        // when
+        timeCapsuleService.unlike(userId, capsuleId)
+
+        // then
+        verify(exactly = 0) { capsuleLikeWriter.save(any()) }
+    }
+
+    @Test
+    fun `좋아요 취소시 이미 취소된 상태면 아무것도 하지 않는다`() {
+        // given
+        val userId = 1L
+        val capsuleId = 20L
+        val user = mockk<User>()
+        val capsule = mockk<TimeCapsule>()
+        val existingLike = spyk(TimeCapsuleLike.of(user, capsule))
+        existingLike.isLiked = false
+
+        every { capsuleLikeReader.findByUserIdAndCapsuleId(userId, capsuleId) } returns existingLike
+
+        // when
+        timeCapsuleService.unlike(userId, capsuleId)
+
+        // then
+        verify(exactly = 0) { capsuleLikeWriter.save(any()) }
+    }
+
+    @Test
+    fun `타임캡슐 생성시 openAt이 현재시각보다 이전이면 예외가 발생한다`() {
+        // given
+        val userId = 1L
+        val user = mockk<User>(relaxed = true)
+        val payload = CreateTimeCapsulePayload(
+            title = "title",
+            subtitle = "sub",
+            accessType = AccessType.PRIVATE,
+            openAt = LocalDateTime.now().minusDays(1), // 과거 시간
+            closedAt = LocalDateTime.now(),
+        )
 
         every { userReader.getById(userId) } returns user
+
+        // when & then
+        val exception = assertThrows<ApiErrorException> {
+            timeCapsuleService.createTimeCapsule(userId, payload)
+        }
+
+        assertThat(exception.error.message).isEqualTo(ErrorMessages.INVALID_OPEN_AT.message)
+    }
+
+    @Test
+    fun `타임캡슐 생성시 closedAt이 openAt보다 늦으면 예외가 발생한다`() {
+        // given
+        val userId = 1L
+        val user = mockk<User>(relaxed = true)
+        val payload = CreateTimeCapsulePayload(
+            title = "title",
+            subtitle = "sub",
+            accessType = AccessType.PRIVATE,
+            openAt = LocalDateTime.now().plusDays(5),
+            closedAt = LocalDateTime.now().plusDays(10), // openAt보다 늦음
+        )
+
+        every { userReader.getById(userId) } returns user
+
+        // when & then
+        val exception = assertThrows<ApiErrorException> {
+            timeCapsuleService.createTimeCapsule(userId, payload)
+        }
+
+        assertThat(exception.error.message).isEqualTo(ErrorMessages.INVALID_CLOSED_AT.message)
+    }
+
+    @Test
+    fun `타임캡슐 떠나기가 성공하면 사용자가 비활성화된다`() {
+        // given
+        val userId = 1L
+        val capsuleId = 10L
+        val user = mockk<User> { every { id } returns userId }
+        val timeCapsuleUser = spyk(TimeCapsuleUser.of(user, mockk(relaxed = true)))
+        val capsule = mockk<TimeCapsule> {
+            every { timeCapsuleUsers } returns mutableListOf(timeCapsuleUser)
+        }
+
         every { capsuleReader.getById(capsuleId) } returns capsule
-        every { capsule.timeCapsuleUsers } returns mutableListOf(timeCapsuleUser)
 
         // when
         timeCapsuleService.leaveTimeCapsule(userId, capsuleId)
 
         // then
-        assertThat(timeCapsuleUser.status).isEqualTo(TimeCapsuleUserStatus.LEFT)
         verify { timeCapsuleUser.leave() }
     }
 
     @Test
-    fun `참여하지 않은 사용자가 캡슐을 나가려고 하면 예외가 발생한다`() {
+    fun `참여하지 않은 타임캡슐에서 떠나기를 시도하면 예외가 발생한다`() {
         // given
         val userId = 1L
-        val capsuleId = 50L
-        val user = mockk<User> { every { id } returns userId }
-        val capsule = mockk<TimeCapsule>(relaxed = true)
+        val capsuleId = 10L
+        val capsule = mockk<TimeCapsule> {
+            every { timeCapsuleUsers } returns mutableListOf()
+        }
 
-        every { userReader.getById(userId) } returns user
         every { capsuleReader.getById(capsuleId) } returns capsule
-        every { capsule.timeCapsuleUsers } returns mutableListOf()
 
         // when & then
-        val exception =
-            assertThrows<ApiErrorException> {
-                timeCapsuleService.leaveTimeCapsule(userId, capsuleId)
-            }
+        val exception = assertThrows<ApiErrorException> {
+            timeCapsuleService.leaveTimeCapsule(userId, capsuleId)
+        }
 
         assertThat(exception.error.message).isEqualTo(ErrorMessages.NOT_JOINED_CAPSULE.message)
     }
 
     @Test
-    fun `이미 나간 사용자가 다시 나가려고 하면 예외가 발생한다`() {
+    fun `이미 떠난 타임캡슐에서 다시 떠나기를 시도하면 예외가 발생한다`() {
         // given
         val userId = 1L
-        val capsuleId = 60L
+        val capsuleId = 10L
         val user = mockk<User> { every { id } returns userId }
-        val capsule = mockk<TimeCapsule>(relaxed = true)
-        val timeCapsuleUser = spyk(TimeCapsuleUser.of(user, capsule))
-        timeCapsuleUser.status = TimeCapsuleUserStatus.LEFT
+        val timeCapsuleUser = spyk(TimeCapsuleUser.of(user, mockk(relaxed = true)))
+        timeCapsuleUser.leave() // 이미 떠난 상태
+        val capsule = mockk<TimeCapsule> {
+            every { timeCapsuleUsers } returns mutableListOf(timeCapsuleUser)
+        }
 
-        every { userReader.getById(userId) } returns user
         every { capsuleReader.getById(capsuleId) } returns capsule
-        every { capsule.timeCapsuleUsers } returns mutableListOf(timeCapsuleUser)
 
         // when & then
-        val exception =
-            assertThrows<ApiErrorException> {
-                timeCapsuleService.leaveTimeCapsule(userId, capsuleId)
-            }
+        val exception = assertThrows<ApiErrorException> {
+            timeCapsuleService.leaveTimeCapsule(userId, capsuleId)
+        }
 
         assertThat(exception.error.message).isEqualTo(ErrorMessages.NOT_JOINED_CAPSULE.message)
     }
 
     @Test
-    fun `나간 사용자가 있는 캡슐에서 활성 사용자만 참여 체크된다`() {
+    fun `타임캡슐을 처음 열면 isFirstOpen이 true로 반환된다`() {
         // given
-        val userId1 = 1L
-        val userId2 = 2L
-        val capsuleId = 70L
-        val user1 = mockk<User> { every { id } returns userId1 }
-        val user2 = mockk<User> { every { id } returns userId2 }
-        val capsule = mockk<TimeCapsule>(relaxed = true)
+        val capsuleId = 1L
+        val userId = 10L
+        val timeCapsuleUser = spyk(TimeCapsuleUser.of(mockk(relaxed = true), mockk(relaxed = true)))
+        timeCapsuleUser.isOpened = false
 
-        val activeUser = spyk(TimeCapsuleUser.of(user1, capsule)) // ACTIVE 상태
-        val leftUser = spyk(TimeCapsuleUser.of(user2, capsule))
-        leftUser.status = TimeCapsuleUserStatus.LEFT // LEFT 상태
-
-        every { userReader.getById(userId1) } returns user1
-        every { capsuleReader.getById(capsuleId) } returns capsule
-        every { capsule.timeCapsuleUsers } returns mutableListOf(activeUser, leftUser)
-        every { capsule.closedAt } returns LocalDateTime.now().plusDays(1)
-
-        // when & then - 활성 사용자는 이미 참여한 것으로 인식
-        val exception =
-            assertThrows<ApiErrorException> {
-                timeCapsuleService.joinTimeCapsule(userId1, capsuleId)
-            }
-        assertThat(exception.error.message).isEqualTo(ErrorMessages.ALREADY_JOINED.message)
-    }
-
-    @Test
-    fun `LEFT 상태인 사용자는 다시 참여할 수 있다`() {
-        // given
-        val userId = 1L
-        val capsuleId = 80L
-        val user = mockk<User>(relaxed = true) { every { id } returns userId }
-        val capsule = mockk<TimeCapsule>(relaxed = true)
-        val timeCapsuleUser = spyk(TimeCapsuleUser.of(user, capsule))
-        timeCapsuleUser.status = TimeCapsuleUserStatus.LEFT
-
-        every { userReader.getById(userId) } returns user
-        every { capsuleReader.getById(capsuleId) } returns capsule
-        every { capsule.timeCapsuleUsers } returns mutableListOf(timeCapsuleUser)
-        every { capsule.closedAt } returns LocalDateTime.now().plusDays(1)
+        every { capsuleUserReader.findTimeCapsuleUser(capsuleId, userId) } returns timeCapsuleUser
 
         // when
-        timeCapsuleService.joinTimeCapsule(userId, capsuleId)
+        val result = timeCapsuleService.openTimeCapsule(capsuleId, userId)
 
         // then
-        verify { capsule.addUser(any()) }
-        verify { user.addTimeCapsuleUser(any()) }
+        assertThat(result.isFirstOpen).isTrue()
+        verify { timeCapsuleUser.updateOpened() }
+    }
+
+    @Test
+    fun `이미 열린 타임캡슐을 다시 열면 isFirstOpen이 false로 반환된다`() {
+        // given
+        val capsuleId = 1L
+        val userId = 10L
+        val timeCapsuleUser = spyk(TimeCapsuleUser.of(mockk(relaxed = true), mockk(relaxed = true)))
+        timeCapsuleUser.isOpened = true
+
+        every { capsuleUserReader.findTimeCapsuleUser(capsuleId, userId) } returns timeCapsuleUser
+
+        // when
+        val result = timeCapsuleService.openTimeCapsule(capsuleId, userId)
+
+        // then
+        assertThat(result.isFirstOpen).isFalse()
+        verify(exactly = 0) { timeCapsuleUser.updateOpened() }
+    }
+
+    @Test
+    fun `userId가 null이면 isFirstOpen이 false로 반환된다`() {
+        // given
+        val capsuleId = 1L
+
+        // when
+        val result = timeCapsuleService.openTimeCapsule(capsuleId, null)
+
+        // then
+        assertThat(result.isFirstOpen).isFalse()
+        verify(exactly = 0) { capsuleUserReader.findTimeCapsuleUser(any(), any()) }
+    }
+
+    @Test
+    fun `참여하지 않은 사용자가 타임캡슐을 열면 isFirstOpen이 false로 반환된다`() {
+        // given
+        val capsuleId = 1L
+        val userId = 10L
+
+        every { capsuleUserReader.findTimeCapsuleUser(capsuleId, userId) } returns null
+
+        // when
+        val result = timeCapsuleService.openTimeCapsule(capsuleId, userId)
+
+        // then
+        assertThat(result.isFirstOpen).isFalse()
     }
 }


### PR DESCRIPTION
## 📌 Related Issue

> [!NOTE]
> 관련된 이슈 번호를 적어주세요.

- Close #123 
- Close #128 

## 🚀 Description

> [!NOTE]
> 작업한 내용을 간략히 적어주세요.

```text
타임캡슐 오픈시 첫 오픈 여부 반환 로직 수정
```

## 📸 Screenshot
> [!NOTE]
> 변경 사항을 보여주는 스크린샷(또는 GIF)을 첨부해 주세요.

## 📢 Notes

> [!NOTE]
> 추가적인 설명이나 참고 사항을 작성해 주세요.

```text

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 타임캡슐 열기 API 추가 (POST /api/v1/capsules/{capsuleId}/open): 최초 열림 여부(isFirstOpen) 반환, 비로그인 호출 허용.
  - 타임캡슐 좋아요/좋아요 취소 흐름 개선: 좋아요 추가/취소(API 포함) 및 관련 사용자 상호작용 개선.

- **Documentation**
  - Swagger에 신규 엔드포인트 및 응답 스펙 반영.

- **Chores**
  - 일부 참여 관련 API에 Deprecated 표기 추가.
- **Bug Fixes**
  - 생성 시 openAt/closedAt 입력 검증 추가로 잘못된 일정 입력 방지.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->